### PR TITLE
chore: update compatibility date

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,6 +1,6 @@
 {
   "name": "hpc-project-assistant",
-  "compatibility_date": "2025-08-11",
+  "compatibility_date": "2025-08-10",
   "assets": {
     "directory": "."
   }


### PR DESCRIPTION
## Summary
- set worker compatibility date to 2025-08-10 to avoid using a future date

## Testing
- `npx wrangler deploy --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_6899fd8516a88324a3b77869d4d1a1d2