### PR TITLE
Improve timeline color contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -1861,6 +1861,39 @@
     background: #94a3b8;
   }
 </style>
+
+<style>
+  /* Change timeline background to white for better contrast */
+  .timeline-container, .graph-container {
+    background-color: #ffffff !important;
+  }
+
+  /* Task labels: Make text black and bolder */
+  .task-name, .timeline-label {
+    color: #000000 !important;
+    font-weight: bold;
+    font-size: 14px;
+  }
+
+  /* Bars: Darken grays and pinks for contrast */
+  .task-bar {
+    background-color: #4a4a4a !important;
+    border: 1px solid #000000 !important;
+  }
+  .task-bar.low-priority {
+    background-color: #a52a2a !important;
+  }
+
+  /* Red text/outlines: Tone down to darker red if too bright */
+  .critical, .error {
+    color: #8b0000 !important;
+  }
+
+  /* Overall app: Ensure no gradient bleed */
+  body {
+    background: #ffffff !important;
+  }
+</style>
 </head>
 <body>
   <a href="#appRoot" class="skip-link">Skip to main content</a>


### PR DESCRIPTION
## Summary
- Override timeline and graph containers with white background for clearer contrast
- Darken task bars and labels for better readability
- Tone down red elements and remove gradient background bleed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a251a3ebc8324aa26bfe48f861099