### PR TITLE
Improve scroll and zoom interactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -665,7 +665,7 @@
     border-radius: var(--radius-lg);
     padding: 0;
     min-height: 60vh;
-    overflow: hidden;
+    overflow: visible;
     position: relative;
     box-shadow: var(--shadow);
   }
@@ -3133,7 +3133,26 @@ function makeZoomPan(svg){
   function fit(){ const w=svg.clientWidth||800, h=svg.clientHeight||500; setVB(0,0,w,h); }
   fit();
   let dragging=false; let p0=null, panTicking=false, lastPanX, lastPanY;
-  svg.addEventListener('wheel', (e)=>{ e.preventDefault(); const scale = e.deltaY>0? 1.1 : 0.9; const mx=e.offsetX, my=e.offsetY; const nx = vb[0] + (mx/vb[2])*vb[2]*(1-scale); const ny = vb[1] + (my/vb[3])*vb[3]*(1-scale); const nw = vb[2]*scale; const nh = vb[3]*scale; setVB(nx, ny, nw, nh); });
+  svg.addEventListener('wheel', (e)=>{
+    if (e.ctrlKey) {
+      e.preventDefault();
+      const scale = e.deltaY>0? 1.1 : 0.9;
+      const mx=e.offsetX, my=e.offsetY;
+      const nx = vb[0] + (mx/vb[2])*vb[2]*(1-scale);
+      const ny = vb[1] + (my/vb[3])*vb[3]*(1-scale);
+      const nw = vb[2]*scale; const nh = vb[3]*scale;
+      setVB(nx, ny, nw, nh);
+    } else if (e.shiftKey) {
+      e.preventDefault();
+      const dx = e.deltaY || e.deltaX;
+      setVB(vb[0] + dx, vb[1], vb[2], vb[3]);
+    } else {
+      e.preventDefault();
+      const dy = e.deltaY;
+      setVB(vb[0], vb[1] + dy, vb[2], vb[3]);
+    }
+  }, {passive:false});
+  svg.addEventListener('dblclick', (e)=>{ e.preventDefault(); fit(); });
   svg.addEventListener('pointerdown', (e)=>{ if(e.button!==0) return; dragging=true; p0={x:e.clientX, y:e.clientY, vb0:[...vb]}; svg.setPointerCapture(e.pointerId); });
   svg.addEventListener('pointermove', (e)=>{
     if(!dragging) return;


### PR DESCRIPTION
## Summary
- Allow main content to scroll by removing overflow constraint on the `main` container
- Implement flexible wheel handler: Ctrl+Wheel zooms, Shift+Wheel pans horizontally, vertical wheel pans vertically
- Support double-clicking canvases to reset zoom

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f2a286bc8324bc4986164d033a7c