### PR TITLE
feat: add schema validation for project import/export

### DIFF
--- a/index.html
+++ b/index.html
@@ -2993,6 +2993,7 @@ let cpmWorker;
 let cpmRequestActive = false;
 let lastCPMResult = null;
 let graphInitialized = false;
+const SCHEMA_VERSION = '1.0.0';
 
 
 // ----------------------------[ UTILITIES ]----------------------------
@@ -4148,8 +4149,19 @@ function buildCompare(){
 // ------------------------------------------------------------------------------------
 async function saveFile(json){ const blob=new Blob([json],{type:'application/json'}); if(window.showSaveFilePicker){ try{ const handle=await showSaveFilePicker({suggestedName:'project.hpc.json', types:[{description:'JSON', accept:{'application/json':['.json']}}]}); const w=await handle.createWritable(); await w.write(blob); await w.close(); return; }catch(e){ console.warn(e);} } const a=document.createElement('a'); a.href=URL.createObjectURL(blob); a.download='project.hpc.json'; a.click(); URL.revokeObjectURL(a.href); }
 async function openFile(){ if(window.showOpenFilePicker){ try{ const [h]=await showOpenFilePicker({types:[{description:'JSON/CSV', accept:{'application/json':['.json'],'text/csv':['.csv']}}]}); const f=await h.getFile(); const txt=await f.text(); return f.name.endsWith('.csv')? csvToProject(txt) : JSON.parse(txt); }catch(e){ console.warn(e);} } return new Promise((res)=>{ const inp=document.createElement('input'); inp.type='file'; inp.accept='.json,.csv'; inp.onchange=async()=>{ const f=inp.files[0]; const txt=await f.text(); if(f.name.endsWith('.csv')) res(csvToProject(txt)); else res(JSON.parse(txt)); }; inp.click(); }); }
+function compareVersion(a,b){ const pa=String(a||'').split('.').map(x=>parseInt(x,10)||0); const pb=String(b||'').split('.').map(x=>parseInt(x,10)||0); for(let i=0;i<Math.max(pa.length,pb.length);i++){ const da=pa[i]||0, db=pb[i]||0; if(da>db) return 1; if(da<db) return -1; } return 0; }
+function migrateProject(project){ const fixes=[]; if(!project.tasks) project.tasks=[]; project.tasks=ensureIds(project.tasks); project.schema=SCHEMA_VERSION; return fixes; }
+function validateProject(project){ const errors=[]; const fixed=[]; if(!project||typeof project!=='object'){ errors.push('Project must be an object'); return {ok:false, errors, fixed}; }
+ if(compareVersion(project.schema||'0.0.0', SCHEMA_VERSION)<0){ fixed.push(...migrateProject(project)); }
+ else if(project.schema && compareVersion(project.schema, SCHEMA_VERSION)>0){ errors.push(`Schema ${project.schema} is newer than supported ${SCHEMA_VERSION}`); }
+ if(typeof project.startDate!=='string') errors.push('Missing or invalid startDate');
+ if(typeof project.calendar!=='string'){ project.calendar='workdays'; fixed.push('Set default calendar'); }
+ if(!Array.isArray(project.holidays)){ project.holidays=[]; fixed.push('Reset holidays'); }
+ if(!Array.isArray(project.tasks)){ project.tasks=[]; errors.push('tasks must be an array'); }
+ else { project.tasks=ensureIds(project.tasks); }
+ return {ok: errors.length===0, errors, fixed}; }
 function exportCSV(){ const rows=[['id','name','duration(d)','deps','phase','subsystem']]; for(const t of SM.get().tasks){ if(t.active===false) continue; rows.push([t.id,t.name,parseDurationStrict(t.duration).days||0, (t.deps||[]).join(' '), t.phase||'', t.subsystem||''].map(x=>`"${String(x).replaceAll('"','""')}"`)); } const csv=rows.map(r=>r.join(',')).join('\n'); const a=document.createElement('a'); a.href=URL.createObjectURL(new Blob([csv],{type:'text/csv'})); a.download='project.csv'; a.click(); URL.revokeObjectURL(a.href); }
-function csvToProject(csv){ const lines=csv.trim().split(/\r?\n/); const [header,...rows]=lines; const idx=(k)=> header.split(',').map(s=>s.replace(/\W+/g,'').toLowerCase()).indexOf(k.toLowerCase()); const iId=idx('id'), iName=idx('name'), iDur=idx('durationd'), iDeps=idx('deps'), iPhase=idx('phase'), iSub=idx('subsystem'); const tasks=rows.map(r=>{ const cols=r.match(/\"([^\"]|\"\")*\"|[^,]+/g).map(s=>s.replace(/^\"|\"$/g,'').replaceAll('""','"')); const d=parseDurationStrict(+cols[iDur]||cols[iDur]||''); return { id: cols[iId]||uid('t'), name: cols[iName], duration: d.error? 1 : d.days, deps: (cols[iDeps]||'').split(/[\s;]/).filter(Boolean), phase: cols[iPhase]||'', subsystem: cols[iSub]||'System', active:true }; }); return {startDate: todayStr(), calendar: 'workdays', holidays:[], tasks}; }
+function csvToProject(csv){ const lines=csv.trim().split(/\r?\n/); const [header,...rows]=lines; const idx=(k)=> header.split(',').map(s=>s.replace(/\W+/g,'').toLowerCase()).indexOf(k.toLowerCase()); const iId=idx('id'), iName=idx('name'), iDur=idx('durationd'), iDeps=idx('deps'), iPhase=idx('phase'), iSub=idx('subsystem'); const tasks=rows.map(r=>{ const cols=r.match(/\"([^\"]|\"\")*\"|[^,]+/g).map(s=>s.replace(/^\"|\"$/g,'').replaceAll('""','"')); const d=parseDurationStrict(+cols[iDur]||cols[iDur]||''); return { id: cols[iId]||uid('t'), name: cols[iName], duration: d.error? 1 : d.days, deps: (cols[iDeps]||'').split(/[\s;]/).filter(Boolean), phase: cols[iPhase]||'', subsystem: cols[iSub]||'System', active:true }; }); return {schema: SCHEMA_VERSION, startDate: todayStr(), calendar: 'workdays', holidays:[], tasks}; }
 
 // ----------------------------[ UI: SELECTION & BULK EDIT ]----------------------------
 // Manages task selection, including multi-select and bulk editing operations.
@@ -4493,9 +4505,9 @@ window.addEventListener('DOMContentLoaded', ()=>{
 
     // I/O
     $('#btnExportCSV').onclick=exportCSV;
-    $('#btnExportJSON').onclick=()=>{ const json=JSON.stringify(SM.get(), null, 2); const a=document.createElement('a'); a.href=URL.createObjectURL(new Blob([json],{type:'application/json'})); a.download='project.json'; a.click(); URL.revokeObjectURL(a.href); };
-    $('#btnSave').onclick=()=> saveFile(JSON.stringify(SM.get(), null, 2));
-    $('#btnLoad').onclick=async()=>{ const data=await openFile(); if(!data) return; SM.set({startDate:data.startDate||todayStr(), calendar:data.calendar||'workdays', holidays:data.holidays||[], tasks:ensureIds(data.tasks||[])}, {name: 'Load Project'}); $('#startDate').value=SM.get().startDate; $('#calendarMode').value=SM.get().calendar; $('#holidayInput').value=(SM.get().holidays||[]).join(', '); clearSelection(); refresh(); };
+    $('#btnExportJSON').onclick=()=>{ const json=JSON.stringify({...SM.get(), schema:SCHEMA_VERSION}, null, 2); const a=document.createElement('a'); a.href=URL.createObjectURL(new Blob([json],{type:'application/json'})); a.download='project.json'; a.click(); URL.revokeObjectURL(a.href); };
+    $('#btnSave').onclick=()=> saveFile(JSON.stringify({...SM.get(), schema:SCHEMA_VERSION}, null, 2));
+    $('#btnLoad').onclick=async()=>{ const data=await openFile(); if(!data) return; const rep=validateProject(data); if(!rep.ok){ const msg='Import issues:\n- '+rep.errors.join('\n- '); if(!confirm(msg+'\nImport anyway?')) return; } if(rep.fixed.length) showToast(`Applied ${rep.fixed.length} fix(es).`); SM.set({startDate:data.startDate||todayStr(), calendar:data.calendar||'workdays', holidays:data.holidays||[], tasks:data.tasks||[]}, {name: 'Load Project'}); $('#startDate').value=SM.get().startDate; $('#calendarMode').value=SM.get().calendar; $('#holidayInput').value=(SM.get().holidays||[]).join(', '); clearSelection(); refresh(); };
     $('#btnNew').onclick=newProject; $('#btnPrint').onclick=()=>window.print();
     $('#btnGuide').onclick=()=>document.getElementById('help-modal').style.display = 'flex';
 
@@ -4590,7 +4602,7 @@ window.addEventListener('DOMContentLoaded', ()=>{
 
     // 1. Export JSON
     $('#action-export-json').addEventListener('click', () => {
-      const json = JSON.stringify(SM.get(), null, 2);
+      const json = JSON.stringify({...SM.get(), schema:SCHEMA_VERSION}, null, 2);
       const blob = new Blob([json], {type: 'application/json'});
       const a = document.createElement('a');
       a.href = URL.createObjectURL(blob);
@@ -4607,11 +4619,14 @@ window.addEventListener('DOMContentLoaded', ()=>{
       try {
         const data = await openFile();
         if (!data) return; // User cancelled
+        const rep = validateProject(data);
+        if(!rep.ok){ const msg='Import issues:\n- '+rep.errors.join('\n- '); if(!confirm(msg+'\nImport anyway?')) return; }
+        if(rep.fixed.length) showToast(`Applied ${rep.fixed.length} fix(es).`);
         SM.set({
           startDate: data.startDate || todayStr(),
           calendar: data.calendar || 'workdays',
           holidays: data.holidays || [],
-          tasks: ensureIds(data.tasks || [])
+          tasks: data.tasks || []
         }, { name: 'Import Project' });
 
         // Sync UI to new state


### PR DESCRIPTION
## Summary
- add `SCHEMA_VERSION` constant and project validation/migration helpers
- embed schema info on export and validate on import with optional fixes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a254db013083248af88703cd34682e