### PR TITLE
Render inline editor for Edit Selected menu

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2532,6 +2532,9 @@ document.getElementById('btnToggleSidebar')?.addEventListener('click', (e)=>{
     if(!btn || !menu) return;
     const getItems=()=>Array.from(menu.querySelectorAll('button, [href], input, select, textarea'));
     function openMenu(){
+      if(buttonId==='btn-edit-selected'){
+        renderInlineEditor();
+      }
       menu.style.display='block';
       setTimeout(()=>{ menu.classList.add('open'); btn.setAttribute('aria-expanded','true'); getItems()[0]?.focus(); },10);
     }


### PR DESCRIPTION
## Summary
- Render inline editor immediately before displaying the Edit Selected dropdown

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c03a80508324ab512c6ac26bd915