### PR TITLE
Render inline editor before opening Edit Selected menu

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2522,6 +2522,10 @@ document.getElementById('btnToggleSidebar')?.addEventListener('click', (e)=>{
     });
   });
 
+  document.getElementById('btn-edit-selected')?.addEventListener('click', () => {
+    renderInlineEditor();
+  });
+
 })();
 
 (function(){


### PR DESCRIPTION
## Summary
- Ensure the Edit Selected dropdown invokes `renderInlineEditor` before opening so selection fields populate correctly.

## Testing
- `node --check assets/js/app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c041ab9083249160de305071c7c8