### PR TITLE
Render inline editor when opening Edit Selected dropdown

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1611,6 +1611,7 @@ function renderInlineEditor(){ const box=$('#inlineEdit'); if(!box) return; box.
   }
   box.querySelectorAll('input,select').forEach(inp=>{ inp.addEventListener('change',()=>{ const id=inp.dataset.id; const field=inp.dataset.field; let val=inp.value; if(field==='duration') val=parseInt(val,10)||0; else if(field==='active') val=(val==='true'); else if(field==='pct') val=Math.min(100, Math.max(0, parseInt(val,10)||0)); SM.updateTask(id,{[field]:val}, {name: `Edit ${field}`}); refresh(); }); });
 }
+window.renderInlineEditor = renderInlineEditor;
   function updateSelBadge(){
     $('#selBadge').textContent = `${SEL.size} selected`;
     $('#bulkCount').textContent=String(SEL.size);
@@ -2526,13 +2527,14 @@ document.getElementById('btnToggleSidebar')?.addEventListener('click', (e)=>{
 
 (function(){
   'use strict';
-  function setupDropdown(buttonId, menuId){
+  function setupDropdown(buttonId, menuId, onOpen){
     const btn=document.getElementById(buttonId);
     const menu=document.getElementById(menuId);
     if(!btn || !menu) return;
     const getItems=()=>Array.from(menu.querySelectorAll('button, [href], input, select, textarea'));
     function openMenu(){
       menu.style.display='block';
+      if(typeof onOpen==='function') onOpen();
       setTimeout(()=>{ menu.classList.add('open'); btn.setAttribute('aria-expanded','true'); getItems()[0]?.focus(); },10);
     }
     function closeMenu(){
@@ -2547,7 +2549,7 @@ document.getElementById('btnToggleSidebar')?.addEventListener('click', (e)=>{
   setupDropdown('btn-project-calendar','menu-project-calendar');
   setupDropdown('btn-filter-group','menu-filter-group');
   setupDropdown('btn-subsystem-legend','menu-subsystem-legend');
-  setupDropdown('btn-edit-selected','menu-edit-selected');
+  setupDropdown('btn-edit-selected','menu-edit-selected', window.renderInlineEditor);
   setupDropdown('btn-bulk-edit','menu-bulk-edit');
   setupDropdown('btn-template','menu-template');
   setupDropdown('btn-validation','menu-validation');


### PR DESCRIPTION
## Summary
- Trigger `renderInlineEditor` whenever the Edit Selected dropdown opens
- Allow dropdown helper to accept an `onOpen` callback for custom actions
- Expose `renderInlineEditor` globally for reuse

## Testing
- `node --check assets/js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68a5c2870d048324b8d72d76394ecaf9