### PR TITLE
Escape quotes in task editor

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -170,7 +170,15 @@ function ddmmyyyy_to_yyyymmdd(s) { if (!s) return ''; const [d,m,y] = s.split('-
 function addDays(date, n){ const d=new Date(date); d.setDate(d.getDate()+n); return d; }
 function isWeekend(d){ const x=d.getDay(); return x===0||x===6; }
 function daysBetween(a,b){ return Math.round((b-a)/86400000); }
-function esc(s){ return String(s??'').replace(/[&<>]/g, c=>({'&':'&amp;','<':'&lt;','>':'&gt;'}[c])); }
+function esc(s){
+  return String(s ?? '').replace(/['"&<>]/g, c => ({
+    "'": '&#39;',
+    '"': '&quot;',
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;'
+  }[c]));
+}
 function uid(prefix='t'){ return prefix+'_'+Math.random().toString(36).slice(2,8); }
 function slug(s){ return String(s||'').toLowerCase().replace(/[^a-z0-9]+/g,'_').replace(/^_|_$/g,''); }
 function clone(o){ return JSON.parse(JSON.stringify(o)); }


### PR DESCRIPTION
## Summary
- Escape single and double quotes in the `esc` utility to safely embed task data into HTML attributes.

## Testing
- `NODE_PATH=/root/.nvm/versions/node/v20.19.4/lib/node_modules node - <<'NODE'
const {JSDOM} = require('jsdom');
function esc(s){
  return String(s ?? '').replace(/['\"&<>]/g, c => ({
    "'": '&#39;',
    '"': '&quot;',
    '&': '&amp;',
    '<': '&lt;',
    '>': '&gt;'
  }[c]));
}
const dom = new JSDOM(`<div id="inlineEdit"></div>`);
const document = dom.window.document;
const name = `Task with \"double\" and 'single' quotes`;
const phase = `Phase 'Alpha' \"Beta\"`;
const rowHtml = `<input type=\"text\" data-field=\"name\" value=\"${esc(name)}\"><input type=\"text\" data-field=\"phase\" value=\"${esc(phase)}\">`;
document.getElementById('inlineEdit').innerHTML = rowHtml;
const values = [...document.querySelectorAll('input')].map(i=>i.value);
console.log(values.join(' | '));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68a5c6dcd9b483248a0b9155c5850520