### PR TITLE
Add tasks table view

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1287,6 +1287,23 @@ function renderIssues(project, cpm, targetSel) {
     }
 }
 
+function renderTasksTable(project, cpm){
+  const table = $('#tasksTable');
+  if(!table) return;
+  const tbody = table.querySelector('tbody');
+  if(!tbody) return;
+  const cpmMap = cpm ? Object.fromEntries((cpm.tasks||[]).map(t=>[t.id,t])) : {};
+  tbody.innerHTML='';
+  for(const t of project.tasks){
+    const c = cpmMap[t.id]||{};
+    const dur = parseDurationStrict(t.duration).days||0;
+    const isMilestone = dur===0;
+    const row=document.createElement('tr');
+    row.innerHTML=`<td>${esc(t.id)}</td><td>${esc(t.name)}</td><td>${dur}</td><td>${esc((t.deps||[]).join(' '))}</td><td>${esc(t.subsystem||'')}</td><td>${esc(t.phase||'')}</td><td>${t.pct||0}</td><td>${c.critical?'Yes':'No'}</td><td>${isMilestone?'Yes':'No'}</td>`;
+    tbody.appendChild(row);
+  }
+}
+
 function renderContextPanel(selectedId) {
   const sidePanel = $('#side');
   if (!selectedId) {
@@ -1683,6 +1700,7 @@ function renderAll(project, cpm) {
     // }
     renderFocus(project, cpm);
     renderIssues(project, cpm);
+    renderTasksTable(project, cpm);
     renderContextPanel(LAST_SEL);
     $('#boot').style.display='none';
     $('#appRoot').style.display='grid';
@@ -1817,6 +1835,9 @@ window.addEventListener('DOMContentLoaded', ()=>{
 
         if(viewId==='compare') {
             buildCompare();
+        }
+        if(viewId==='tasks') {
+            renderTasksTable(SM.get(), lastCPMResult);
         }
     });
 

--- a/index.html
+++ b/index.html
@@ -359,6 +359,7 @@
             <div class="tab" data-tab="graph" role="tab" aria-selected="false" aria-controls="graph">Dependency Graph</div>
             <div class="tab" data-tab="focus" role="tab" aria-selected="false" aria-controls="focus">Where to focus</div>
             <div class="tab" data-tab="compare" role="tab" aria-selected="false" aria-controls="compare">Compare</div>
+            <div class="tab" data-tab="tasks" role="tab" aria-selected="false" aria-controls="tasks">Tasks table</div>
             <div class="view-controls" style="margin-left: auto; display: flex; align-items: center; gap: var(--spacing-md);">
                 <span style="margin-left:.5rem">Graph</span>
                 <button class="btn small" id="zoomOutGR" aria-label="Zoom out graph">−</button>
@@ -443,6 +444,24 @@
             <h3>Task deltas (start / finish / slack)</h3>
             <div class="list" id="cmpList"></div>
             </div>
+        </section>
+        <section id="tasks" class="view" role="tabpanel" aria-label="Tasks table view" tabindex="0">
+            <table class="table" id="tasksTable" aria-label="Project tasks table">
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Name</th>
+                        <th>Duration</th>
+                        <th>Dependencies</th>
+                        <th>Subsystem</th>
+                        <th>Phase</th>
+                        <th>%</th>
+                        <th>Critical</th>
+                        <th>Milestone</th>
+                    </tr>
+                </thead>
+                <tbody></tbody>
+            </table>
         </section>
         </main>
     </section>


### PR DESCRIPTION
## Summary
- add Tasks table tab alongside Timeline, Dependency Graph, Where to focus, and Compare
- render full task list in a table with key attributes like id, duration, subsystem, phase, progress, and criticality
- refresh and display the table when switching to the new tab

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e0f4b86883249359094ce8a6b243