### PR TITLE
Add tasks table view for project overview

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1498,6 +1498,24 @@ function buildCompare(){
   });
 }
 
+function buildTasksTable(){
+  const tbody = document.querySelector('#tasksTable tbody');
+  if(!tbody) return;
+  tbody.innerHTML='';
+  const tasks = SM.get().tasks || [];
+  const cpmMap = lastCPMResult ? Object.fromEntries(lastCPMResult.tasks.map(t=>[t.id,t])) : {};
+  for(const t of tasks){
+    if(t.active===false) continue;
+    const dur = parseDurationStrict(t.duration).days || 0;
+    const deps = (t.deps||[]).join(' ');
+    const crit = cpmMap[t.id]?.critical ? 'Yes' : '';
+    const milestone = dur===0 ? 'Yes' : '';
+    const tr=document.createElement('tr');
+    tr.innerHTML=`<td>${esc(t.id)}</td><td>${esc(t.name)}</td><td>${dur}</td><td>${esc(deps)}</td><td>${esc(t.subsystem||'')}</td><td>${esc(t.phase||'')}</td><td>${t.pct||0}</td><td>${crit}</td><td>${milestone}</td>`;
+    tbody.appendChild(tr);
+  }
+}
+
 
 // ----------------------------[ DATA IMPORT/EXPORT ]----------------------------
 // Functions for handling file I/O, including saving/loading projects and CSV export.
@@ -1817,6 +1835,9 @@ window.addEventListener('DOMContentLoaded', ()=>{
 
         if(viewId==='compare') {
             buildCompare();
+        }
+        if (viewId === 'tasks') {
+            buildTasksTable();
         }
     });
 

--- a/index.html
+++ b/index.html
@@ -359,6 +359,10 @@
             <div class="tab" data-tab="graph" role="tab" aria-selected="false" aria-controls="graph">Dependency Graph</div>
             <div class="tab" data-tab="focus" role="tab" aria-selected="false" aria-controls="focus">Where to focus</div>
             <div class="tab" data-tab="compare" role="tab" aria-selected="false" aria-controls="compare">Compare</div>
+            <div class="tab" data-tab="tasks" role="tab"
+                 aria-selected="false" aria-controls="tasks">
+              Tasks table
+            </div>
             <div class="view-controls" style="margin-left: auto; display: flex; align-items: center; gap: var(--spacing-md);">
                 <span style="margin-left:.5rem">Graph</span>
                 <button class="btn small" id="zoomOutGR" aria-label="Zoom out graph">−</button>
@@ -443,6 +447,22 @@
             <h3>Task deltas (start / finish / slack)</h3>
             <div class="list" id="cmpList"></div>
             </div>
+        </section>
+        <section id="tasks" class="view"
+                 role="tabpanel"
+                 aria-label="Project tasks table view"
+                 aria-live="polite"
+                 tabindex="0">
+          <table class="table" id="tasksTable">
+            <thead>
+              <tr>
+                <th scope="col">Id</th><th scope="col">Name</th><th scope="col">Duration</th><th scope="col">Deps</th>
+                <th scope="col">Subsystem</th><th scope="col">Phase</th><th scope="col">%</th>
+                <th scope="col">Critical</th><th scope="col">Milestone</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
         </section>
         </main>
     </section>


### PR DESCRIPTION
## Summary
- add new "Tasks table" tab and view with accessible table layout
- implement `buildTasksTable` to populate table from project tasks and CPM results
- load tasks table when its tab is activated

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e5a6e59c832494fa9ab26578ee18