### PR TITLE
feat: add tasks table view

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1287,6 +1287,21 @@ function renderIssues(project, cpm, targetSel) {
     }
 }
 
+function renderTaskTable(project, cpm){
+  const body=$('#taskTableBody');
+  if(!body) return;
+  body.innerHTML='';
+  if(!cpm) return;
+  const tasks=cpm.tasks.filter(matchesFilters);
+  for(const t of tasks){
+    const row=document.createElement('tr');
+    const dur=parseDurationStrict(t.duration).days||0;
+    const deps=(t.deps||[]).map(esc).join(', ');
+    row.innerHTML=`<td>${esc(t.id)}</td><td>${esc(t.name)}</td><td>${dur}</td><td>${deps}</td><td>${esc(t.subsystem||'')}</td><td>${esc(t.phase||'')}</td><td>${t.pct||0}</td><td>${t.critical?'✓':''}</td><td>${dur===0?'✓':''}</td>`;
+    body.appendChild(row);
+  }
+}
+
 function renderContextPanel(selectedId) {
   const sidePanel = $('#side');
   if (!selectedId) {
@@ -1687,6 +1702,7 @@ function renderAll(project, cpm) {
     $('#boot').style.display='none';
     $('#appRoot').style.display='grid';
     if($('.tab.active').dataset.tab==='compare') buildCompare();
+    if($('.tab.active').dataset.tab==='tasks') renderTaskTable(project, cpm);
 }
 
 function refresh(){
@@ -1817,6 +1833,9 @@ window.addEventListener('DOMContentLoaded', ()=>{
 
         if(viewId==='compare') {
             buildCompare();
+        }
+        if(viewId==='tasks') {
+            renderTaskTable(SM.get(), lastCPMResult);
         }
     });
 

--- a/index.html
+++ b/index.html
@@ -359,6 +359,7 @@
             <div class="tab" data-tab="graph" role="tab" aria-selected="false" aria-controls="graph">Dependency Graph</div>
             <div class="tab" data-tab="focus" role="tab" aria-selected="false" aria-controls="focus">Where to focus</div>
             <div class="tab" data-tab="compare" role="tab" aria-selected="false" aria-controls="compare">Compare</div>
+            <div class="tab" data-tab="tasks" role="tab" aria-controls="tasks">Tasks table</div>
             <div class="view-controls" style="margin-left: auto; display: flex; align-items: center; gap: var(--spacing-md);">
                 <span style="margin-left:.5rem">Graph</span>
                 <button class="btn small" id="zoomOutGR" aria-label="Zoom out graph">−</button>
@@ -443,6 +444,15 @@
             <h3>Task deltas (start / finish / slack)</h3>
             <div class="list" id="cmpList"></div>
             </div>
+        </section>
+        <section id="tasks" class="view" role="tabpanel" aria-label="Tasks table view" tabindex="0">
+          <table class="table">
+            <thead><tr>
+              <th>ID</th><th>Name</th><th>Duration</th><th>Deps</th>
+              <th>Subsystem</th><th>Phase</th><th>%</th><th>Critical</th><th>Milestone</th>
+            </tr></thead>
+            <tbody id="taskTableBody"></tbody>
+          </table>
         </section>
         </main>
     </section>


### PR DESCRIPTION
## Summary
- add tasks table tab and view with basic table layout
- render task details in a table and update when switching tabs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e591bb188324a65510e27e3e4ecb