### PR TITLE
Add configurable timeline units for Gantt chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -372,6 +372,10 @@
             <button class="btn small" id="zoomOutTL" aria-label="Zoom out timeline">−</button>
             <button class="btn small" id="zoomInTL" aria-label="Zoom in timeline">+</button>
             <button class="btn small" id="zoomResetTL" aria-label="Reset timeline zoom">Fit</button>
+            <select id="axisUnit">
+              <option value="months">Months</option>
+              <option value="weeks">Weeks</option>
+            </select>
             </div>
             <svg id="gantt" class="gantt" role="img" aria-label="Project timeline" tabindex="0"></svg>
             <div id="gantt-accessible-summary" class="sr-only" aria-live="polite"></div>


### PR DESCRIPTION
## Summary
- persist `timelineUnit` setting with default months
- add select control to choose months or weeks in the timeline toolbar
- render Gantt axis with calendar-based month or week ticks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6cdbc72b083249c6d17e88511e700