### PR TITLE
Add timeline axis unit selector with date-based ticks

### DIFF
--- a/index.html
+++ b/index.html
@@ -372,6 +372,10 @@
             <button class="btn small" id="zoomOutTL" aria-label="Zoom out timeline">−</button>
             <button class="btn small" id="zoomInTL" aria-label="Zoom in timeline">+</button>
             <button class="btn small" id="zoomResetTL" aria-label="Reset timeline zoom">Fit</button>
+            <select id="tlAxisUnit" aria-label="Timeline axis unit">
+                <option value="months" selected>Months</option>
+                <option value="weeks">Weeks</option>
+            </select>
             </div>
             <svg id="gantt" class="gantt" role="img" aria-label="Project timeline" tabindex="0"></svg>
             <div id="gantt-accessible-summary" class="sr-only" aria-live="polite"></div>


### PR DESCRIPTION
## Summary
- add timeline axis unit dropdown to timeline toolbar
- track unit selection in state and announce changes for accessibility
- compute timeline axis ticks using calendar dates for months or weeks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6cdca9b408324bdf524c797deaa8d