### PR TITLE
Close dropdown when switching tabs

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1829,6 +1829,17 @@ window.addEventListener('DOMContentLoaded', ()=>{
         const viewId = t.dataset.tab;
         $('#'+viewId).classList.add('active');
 
+        // Close any open action menus when switching tabs
+        document.querySelectorAll('.action-menu').forEach(menu => {
+            menu.classList.remove('open');
+            menu.style.display = 'none';
+        });
+        document.querySelectorAll('[aria-haspopup="true"]').forEach(btn => {
+            if(btn.getAttribute('aria-expanded')==='true'){
+                btn.setAttribute('aria-expanded','false');
+            }
+        });
+
         if (viewId === 'graph' && !graphInitialized) {
             if (lastCPMResult) {
                 renderGraph(SM.get(), lastCPMResult);


### PR DESCRIPTION
## Summary
- Hide any open action menus when selecting a different top-level tab so dropdowns don't linger

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d69552b48324acc4c500a72fe79f