### PR TITLE
Close dropdowns and blur selects on tab change

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1821,6 +1821,20 @@ window.addEventListener('DOMContentLoaded', ()=>{
     // reactive
     SM.onChange(()=>{ $('#btnUndo').disabled=!SM.canUndo(); $('#btnRedo').disabled=!SM.canRedo(); updateSelBadge(); });
 
+    function closeAllDropdowns() {
+      if (document.activeElement && document.activeElement.tagName === 'SELECT') {
+        document.activeElement.blur();
+      }
+      $$('.action-menu.open').forEach(menu => {
+        menu.classList.remove('open');
+        menu.style.display = 'none';
+        const btn = document.querySelector(`[aria-controls="${menu.id}"]`) ||
+                    document.getElementById(menu.id.replace('menu-', 'btn-')) ||
+                    menu.previousElementSibling;
+        if (btn) btn.setAttribute('aria-expanded', 'false');
+      });
+    }
+
     // tabs
     $$('.tab').forEach(t=> t.onclick=()=>{
         $$('.tab').forEach(x=>x.classList.remove('active'));
@@ -1828,6 +1842,8 @@ window.addEventListener('DOMContentLoaded', ()=>{
         $$('.view').forEach(v=>v.classList.remove('active'));
         const viewId = t.dataset.tab;
         $('#'+viewId).classList.add('active');
+
+        closeAllDropdowns();
 
         if (viewId === 'graph' && !graphInitialized) {
             if (lastCPMResult) {


### PR DESCRIPTION
## Summary
- Add `closeAllDropdowns` helper to blur active select elements and close any open action menus
- Invoke dropdown cleanup whenever a tab is selected

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d899c8a88324a91c12a0d053f5c4