### PR TITLE
Close dropdown menus when switching tabs

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1829,6 +1829,14 @@ window.addEventListener('DOMContentLoaded', ()=>{
         const viewId = t.dataset.tab;
         $('#'+viewId).classList.add('active');
 
+        document.querySelectorAll('.action-menu.open').forEach(menu=>{
+            menu.classList.remove('open');
+            menu.style.display = 'none';
+        });
+        if(document.activeElement && typeof document.activeElement.blur === 'function') {
+            document.activeElement.blur();
+        }
+
         if (viewId === 'graph' && !graphInitialized) {
             if (lastCPMResult) {
                 renderGraph(SM.get(), lastCPMResult);


### PR DESCRIPTION
## Summary
- Close any open dropdown menus when switching tabs to avoid lingering overlays
- Blur active element when changing tabs to hide native selects

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node verifyDropdown.js` (test script to simulate tab switch closes dropdown)


------
https://chatgpt.com/codex/tasks/task_e_68a6d8a3be688324aac9e460f08aa16f