### PR TITLE
feat: enforce single open toolbar menu

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2562,22 +2562,27 @@ document.getElementById('btnToggleSidebar')?.addEventListener('click', (e)=>{
 
 (function(){
   'use strict';
+  let activeDropdown=null;
   function setupDropdown(buttonId, menuId, onOpen){
     const btn=document.getElementById(buttonId);
     const menu=document.getElementById(menuId);
     if(!btn || !menu) return;
     const getItems=()=>Array.from(menu.querySelectorAll('button, [href], input, select, textarea'));
+    let api;
     function openMenu(){
       menu.style.display='block';
       if(typeof onOpen==='function') onOpen();
       setTimeout(()=>{ menu.classList.add('open'); btn.setAttribute('aria-expanded','true'); getItems()[0]?.focus(); },10);
+      activeDropdown=api;
     }
     function closeMenu(){
       menu.classList.remove('open');
       btn.setAttribute('aria-expanded','false');
       setTimeout(()=>{ if(!menu.classList.contains('open')) menu.style.display='none'; },150);
+      if(activeDropdown===api) activeDropdown=null;
     }
-    btn.addEventListener('click',(e)=>{ e.stopPropagation(); const exp=btn.getAttribute('aria-expanded')==='true'; exp?closeMenu():openMenu(); });
+    api={closeMenu};
+    btn.addEventListener('click',(e)=>{ e.stopPropagation(); const exp=btn.getAttribute('aria-expanded')==='true'; if(exp){ closeMenu(); } else { if(activeDropdown && activeDropdown!==api) activeDropdown.closeMenu(); openMenu(); }});
     document.addEventListener('click',(e)=>{ const exp=btn.getAttribute('aria-expanded')==='true'; if(exp && !menu.contains(e.target) && !btn.contains(e.target)) closeMenu(); });
     menu.addEventListener('keydown',(e)=>{ if(e.key==='Escape'){ closeMenu(); return; } if(e.key==='Tab'){ const items=getItems(); if(items.length){ const first=items[0]; const last=items[items.length-1]; if(e.shiftKey && document.activeElement===first){ e.preventDefault(); last.focus(); } else if(!e.shiftKey && document.activeElement===last){ e.preventDefault(); first.focus(); } } }});
   }


### PR DESCRIPTION
## Summary
- track the active dropdown menu in `setupDropdown`
- close any previously open menu before opening a new one
- register/unregister the active menu when toggling

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node test_dropdown.js`

------
https://chatgpt.com/codex/tasks/task_e_68a6e079f78c83248bbdaba023793914