### PR TITLE
fix: stabilize Gantt left gutter

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const SCHEMA_VERSION = '1.0.0';
+const LEFT_GUTTER = 220;
 
 /**
  * =============================================================================
@@ -870,8 +871,7 @@ function renderGraph(project, cpm){
 
 function colorFor(subsys){ const M={'power/VRM':'--pwr','PCIe':'--pcie','BMC':'--bmc','BIOS':'--bios','FW':'--fw','Mech':'--mech','Thermal':'--thermal','System':'--sys'}; const v=M[subsys]||'--ok'; return getComputedStyle(document.documentElement).getPropertyValue(v).trim()||'#16a34a'; }
 function renderGantt(project, cpm){ const svg=$('#gantt'); svg.innerHTML=''; const W=(svg.getBoundingClientRect().width||800); const H=(svg.getBoundingClientRect().height||500); const tasksAll=cpm.tasks.slice(); const tasks=tasksAll.filter(matchesFilters);
-  const maxLen = Math.max(20, ...tasks.map(t=>(t.name||'').length));
-  const P = Math.min(400, 10 + maxLen * 8.5);
+  const P = LEFT_GUTTER;
   const cal=makeCalendar(project.calendar, new Set(project.holidays||[]));
   // grouping
   const groups={}; const order=[]; for(const t of tasks){ const k=groupKey(t); if(k==null){ order.push(['', [t]]); continue; } if(!groups[k]) groups[k]=[]; groups[k].push(t); }


### PR DESCRIPTION
## Summary
- introduce module-level LEFT_GUTTER constant
- use LEFT_GUTTER for Gantt rendering and scaling instead of dynamic max length

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node - <<'NODE'
const LEFT_GUTTER=220;
const W=800;
const finish=100;
const scale = x => LEFT_GUTTER + (x*(W-LEFT_GUTTER-20))/finish;
const tasks=[{name:'Task A', es:10},{name:'Task B', es:20}];
const positionsBefore = tasks.map(t=>scale(t.es));
tasks[0].name='A very very long task name that would previously shift positions';
const positionsAfter = tasks.map(t=>scale(t.es));
console.log('before', positionsBefore);
console.log('after', positionsAfter);
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68a70d52c54483248d45cf7f0b5fe4f6