### PR TITLE
refactor: isolate CPM engine

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -470,7 +470,7 @@ const WarningEngine = (function() {
   return { run };
 })();
 
-// The computeCPM function is now in the worker.
+// The computeCPM function is provided by core/cpm.js and used by the worker and main thread.
 
 // ----------------------------[ ISSUE VALIDATION ENGINE ]----------------------------
 // Rule-based engine to collect validation issues, warnings, and errors in the project.

--- a/assets/js/core/cpm.js
+++ b/assets/js/core/cpm.js
@@ -1,0 +1,84 @@
+'use strict';
+
+function computeCPM(project){
+  const cal = makeCalendar(project.calendar, new Set(project.holidays||[]));
+  const active = project.tasks.filter(t=>t.active!==false);
+  const id2 = Object.fromEntries(active.map(t=>[t.id,t]));
+
+  const predMap = new Map(active.map(t=>[t.id, normalizeDeps(t).filter(e=>id2[e.pred]) ]));
+  const succMap = new Map(active.map(t=>[t.id, []]));
+  for(const [sid,edges] of predMap){
+    for(const e of edges){
+      if(!succMap.has(e.pred)) succMap.set(e.pred,[]);
+      succMap.get(e.pred).push({to:sid, type:e.type, lag:e.lag});
+    }
+  }
+
+  const indeg = new Map(active.map(t=>[t.id,0]));
+  for(const [sid,edges] of predMap){
+    for(const e of edges){ indeg.set(sid, (indeg.get(sid)||0)+1); }
+  }
+  const q=[]; for(const t of active){ if((indeg.get(t.id)||0)===0) q.push(t.id); }
+  const order=[]; while(q.length){ const u=q.shift(); order.push(u); for(const arc of (succMap.get(u)||[])){ const v=arc.to; indeg.set(v, (indeg.get(v)||0)-1); if(indeg.get(v)===0) q.push(v); } }
+
+  const usable=active.filter(t=>order.includes(t.id));
+
+  const ES={}, EF={}; const warnings=[];
+  for(const id of order){
+    const t=id2[id]; if(!t) continue;
+    const dur = parseDuration(t.duration).days||0;
+    let baseES=0;
+    for(const e of (predMap.get(id)||[])){
+      const p=e.pred; const type=e.type; const lag=e.lag|0; const esP = ES[p]||0; const efP = EF[p]||0;
+      if(type==='FS') baseES=Math.max(baseES, efP + lag);
+      else if(type==='SS') baseES=Math.max(baseES, esP + lag);
+      else if(type==='FF') baseES=Math.max(baseES, efP + lag - dur);
+      else if(type==='SF') baseES=Math.max(baseES, esP + lag - dur);
+    }
+    const sc = t.startConstraint || (t.fixedStart!=null ? {type:'SNET', day:t.fixedStart|0} : null);
+    if(sc){
+      if(sc.type==='SNET') baseES = Math.max(baseES, sc.day|0);
+      else if(sc.type==='MSO'){
+        if(baseES > (sc.day|0)) warnings.push({sev:'error', msg:`MSO violated for ${t.name}: deps force start ${baseES} > ${sc.day}`, taskId:t.id});
+        baseES = Math.max(baseES, sc.day|0);
+      }
+    }
+    ES[id]=baseES; EF[id]=baseES + dur;
+  }
+  const projectFinish = Math.max(0, ...order.map(id=>EF[id]||0));
+
+  const LF={}, LS={};
+  const orderRev = order.slice().reverse();
+  for(const id of orderRev){
+    const t=id2[id]; if(!t) continue;
+    const dur=parseDuration(t.duration).days||0;
+    let baseLF = projectFinish;
+    const succs = succMap.get(id)||[];
+    if(succs.length===0){ baseLF = projectFinish; }
+    for(const arc of succs){
+      const s=arc.to; const type=arc.type; const lag=arc.lag|0; const lsS = LS[s]; const lfS = LF[s];
+      if(lsS==null || lfS==null) continue;
+      if(type==='FS') baseLF = Math.min(baseLF, lsS - lag);
+      else if(type==='SS') baseLF = Math.min(baseLF, (LS[id]==null? (lsS - lag) + dur : Math.min(LF[id]||Infinity, (lsS - lag) + dur) ));
+      else if(type==='FF') baseLF = Math.min(baseLF, lfS - lag);
+      else if(type==='SF') baseLF = Math.min(baseLF, (lfS - lag));
+    }
+    LF[id] = baseLF; LS[id] = baseLF - dur;
+  }
+
+  const out = usable.map(t=>({ ...t,
+    es:ES[t.id]||0, ef:EF[t.id]||parseDuration(t.duration).days||0,
+    ls:LS[t.id]||0, lf:LF[t.id]||parseDuration(t.duration).days||0,
+    slack: (LS[t.id]??0)-(ES[t.id]??0),
+    start: cal.add(parseDate(project.startDate), ES[t.id]||0),
+    finish: cal.add(parseDate(project.startDate), EF[t.id]||0),
+    critical: (LS[t.id]??0)===(ES[t.id]??0)
+  }));
+
+  return {order, tasks: out, finishDays: projectFinish, warnings};
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { computeCPM };
+}
+

--- a/assets/js/cpm-worker.js
+++ b/assets/js/cpm-worker.js
@@ -1,7 +1,7 @@
 'use strict';
 
-// Load shared helpers.
-importScripts('core/date-cal.js', 'core/duration.js', 'core/deps.js');
+// Load shared helpers and CPM engine.
+importScripts('core/date-cal.js', 'core/duration.js', 'core/deps.js', 'core/cpm.js');
 
 // --- GRAPH & DEPENDENCY HELPERS ---
 function findCycles(tasks){
@@ -12,60 +12,6 @@ function findCycles(tasks){
   for(const t of tasks){ if(color[t.id]==null) dfs(t.id); }
   return cycles;
 }
-
-// --- CRITICAL PATH METHOD (CPM) ENGINE ---
-function computeCPM(project){
-  const cal = makeCalendar(project.calendar, new Set(project.holidays||[]));
-  const active = project.tasks.filter(t=>t.active!==false);
-  const id2 = Object.fromEntries(active.map(t=>[t.id,t]));
-
-  const predMap = new Map(active.map(t=>[t.id, normalizeDeps(t).filter(e=>id2[e.pred]) ]));
-  const succMap = new Map(active.map(t=>[t.id, []]));
-  for(const [sid,edges] of predMap){ for(const e of edges){ if(!succMap.has(e.pred)) succMap.set(e.pred,[]); succMap.get(e.pred).push({to:sid, type:e.type, lag:e.lag}); } }
-
-  const indeg = new Map(active.map(t=>[t.id,0]));
-  for(const [sid,edges] of predMap){ for(const e of edges){ indeg.set(sid, (indeg.get(sid)||0)+1); } }
-  const q=[]; for(const t of active){ if((indeg.get(t.id)||0)===0) q.push(t.id); }
-  const order=[]; while(q.length){ const u=q.shift(); order.push(u); for(const arc of (succMap.get(u)||[])){ const v=arc.to; indeg.set(v, (indeg.get(v)||0)-1); if(indeg.get(v)===0) q.push(v); } }
-
-  const usable=active.filter(t=>order.includes(t.id));
-
-  const ES={}, EF={}; const warnings=[];
-  for(const id of order){ const t=id2[id]; if(!t) continue; const dur = parseDuration(t.duration).days||0; let baseES=0; for(const e of (predMap.get(id)||[])){
-      const p=e.pred; const type=e.type; const lag=e.lag|0; const esP = ES[p]||0; const efP = EF[p]||0;
-      if(type==='FS') baseES=Math.max(baseES, efP + lag);
-      else if(type==='SS') baseES=Math.max(baseES, esP + lag);
-      else if(type==='FF') baseES=Math.max(baseES, efP + lag - dur);
-      else if(type==='SF') baseES=Math.max(baseES, esP + lag - dur);
-  }
-  const sc = t.startConstraint || (t.fixedStart!=null ? {type:'SNET', day:t.fixedStart|0} : null);
-  if(sc){ if(sc.type==='SNET') baseES = Math.max(baseES, sc.day|0); else if(sc.type==='MSO'){ if(baseES > (sc.day|0)) warnings.push({sev:'error', msg:`MSO violated for ${t.name}: deps force start ${baseES} > ${sc.day}`, taskId:t.id}); baseES = Math.max(baseES, sc.day|0); } }
-  ES[id]=baseES; EF[id]=baseES + dur; }
-  const projectFinish = Math.max(0, ...order.map(id=>EF[id]||0));
-
-  const LF={}, LS={};
-  const orderRev = order.slice().reverse();
-  for(const id of orderRev){ const t=id2[id]; if(!t) continue; const dur=parseDuration(t.duration).days||0; let baseLF = projectFinish; const succs = succMap.get(id)||[]; if(succs.length===0){ baseLF = projectFinish; }
-    for(const arc of succs){ const s=arc.to; const type=arc.type; const lag=arc.lag|0; const lsS = LS[s]; const lfS = LF[s]; if(lsS==null || lfS==null) continue;
-      if(type==='FS') baseLF = Math.min(baseLF, lsS - lag);
-      else if(type==='SS') baseLF = Math.min(baseLF, (LS[id]==null? (lsS - lag) + dur : Math.min(LF[id]||Infinity, (lsS - lag) + dur) ));
-      else if(type==='FF') baseLF = Math.min(baseLF, lfS - lag);
-      else if(type==='SF') baseLF = Math.min(baseLF, (lfS - lag));
-    }
-    LF[id] = baseLF; LS[id] = baseLF - dur; }
-
-  const out = usable.map(t=>({ ...t,
-    es:ES[t.id]||0, ef:EF[t.id]||parseDuration(t.duration).days||0,
-    ls:LS[t.id]||0, lf:LF[t.id]||parseDuration(t.duration).days||0,
-    slack: (LS[t.id]??0)-(ES[t.id]??0),
-    start: cal.add(parseDate(project.startDate), ES[t.id]||0),
-    finish: cal.add(parseDate(project.startDate), EF[t.id]||0),
-    critical: (LS[t.id]??0)===(ES[t.id]??0)
-  }));
-
-  return {order, tasks: out, finishDays: projectFinish, warnings};
-}
-
 
 // --- Worker message handler ---
 self.onmessage = function(e) {

--- a/index.html
+++ b/index.html
@@ -562,11 +562,12 @@
 <script defer src="assets/js/core/date-cal.js"></script>
 <script defer src="assets/js/core/duration.js"></script>
 <script defer src="assets/js/core/deps.js"></script>
+<script defer src="assets/js/core/cpm.js"></script>
 <script id="cpm-worker-src" type="text/plain">
 'use strict';
 
-// Load shared helpers for the worker when running from file://
-importScripts('assets/js/core/date-cal.js','assets/js/core/duration.js','assets/js/core/deps.js');
+// Load shared helpers and CPM engine for the worker when running from file://
+importScripts('assets/js/core/date-cal.js','assets/js/core/duration.js','assets/js/core/deps.js','assets/js/core/cpm.js');
 
 // --- GRAPH & DEPENDENCY HELPERS ---
 function findCycles(tasks){
@@ -577,60 +578,6 @@ function findCycles(tasks){
   for(const t of tasks){ if(color[t.id]==null) dfs(t.id); }
   return cycles;
 }
-
-// --- CRITICAL PATH METHOD (CPM) ENGINE ---
-function computeCPM(project){
-  const cal = makeCalendar(project.calendar, new Set(project.holidays||[]));
-  const active = project.tasks.filter(t=>t.active!==false);
-  const id2 = Object.fromEntries(active.map(t=>[t.id,t]));
-
-  const predMap = new Map(active.map(t=>[t.id, normalizeDeps(t).filter(e=>id2[e.pred]) ]));
-  const succMap = new Map(active.map(t=>[t.id, []]));
-  for(const [sid,edges] of predMap){ for(const e of edges){ if(!succMap.has(e.pred)) succMap.set(e.pred,[]); succMap.get(e.pred).push({to:sid, type:e.type, lag:e.lag}); } }
-
-  const indeg = new Map(active.map(t=>[t.id,0]));
-  for(const [sid,edges] of predMap){ for(const e of edges){ indeg.set(sid, (indeg.get(sid)||0)+1); } }
-  const q=[]; for(const t of active){ if((indeg.get(t.id)||0)===0) q.push(t.id); }
-  const order=[]; while(q.length){ const u=q.shift(); order.push(u); for(const arc of (succMap.get(u)||[])){ const v=arc.to; indeg.set(v, (indeg.get(v)||0)-1); if(indeg.get(v)===0) q.push(v); } }
-
-  const usable=active.filter(t=>order.includes(t.id));
-
-  const ES={}, EF={}; const warnings=[];
-  for(const id of order){ const t=id2[id]; if(!t) continue; const dur = parseDuration(t.duration).days||0; let baseES=0; for(const e of (predMap.get(id)||[])){
-      const p=e.pred; const type=e.type; const lag=e.lag|0; const esP = ES[p]||0; const efP = EF[p]||0;
-      if(type==='FS') baseES=Math.max(baseES, efP + lag);
-      else if(type==='SS') baseES=Math.max(baseES, esP + lag);
-      else if(type==='FF') baseES=Math.max(baseES, efP + lag - dur);
-      else if(type==='SF') baseES=Math.max(baseES, esP + lag - dur);
-  }
-  const sc = t.startConstraint || (t.fixedStart!=null ? {type:'SNET', day:t.fixedStart|0} : null);
-  if(sc){ if(sc.type==='SNET') baseES = Math.max(baseES, sc.day|0); else if(sc.type==='MSO'){ if(baseES > (sc.day|0)) warnings.push({sev:'error', msg:`MSO violated for ${t.name}: deps force start ${baseES} > ${sc.day}`, taskId:t.id}); baseES = Math.max(baseES, sc.day|0); } }
-  ES[id]=baseES; EF[id]=baseES + dur; }
-  const projectFinish = Math.max(0, ...order.map(id=>EF[id]||0));
-
-  const LF={}, LS={};
-  const orderRev = order.slice().reverse();
-  for(const id of orderRev){ const t=id2[id]; if(!t) continue; const dur=parseDuration(t.duration).days||0; let baseLF = projectFinish; const succs = succMap.get(id)||[]; if(succs.length===0){ baseLF = projectFinish; }
-    for(const arc of succs){ const s=arc.to; const type=arc.type; const lag=arc.lag|0; const lsS = LS[s]; const lfS = LF[s]; if(lsS==null || lfS==null) continue;
-      if(type==='FS') baseLF = Math.min(baseLF, lsS - lag);
-      else if(type==='SS') baseLF = Math.min(baseLF, (LS[id]==null? (lsS - lag) + dur : Math.min(LF[id]||Infinity, (lsS - lag) + dur) ));
-      else if(type==='FF') baseLF = Math.min(baseLF, lfS - lag);
-      else if(type==='SF') baseLF = Math.min(baseLF, (lfS - lag));
-    }
-    LF[id] = baseLF; LS[id] = baseLF - dur; }
-
-  const out = usable.map(t=>({ ...t,
-    es:ES[t.id]||0, ef:EF[t.id]||parseDuration(t.duration).days||0,
-    ls:LS[t.id]||0, lf:LF[t.id]||parseDuration(t.duration).days||0,
-    slack: (LS[t.id]??0)-(ES[t.id]??0),
-    start: cal.add(parseDate(project.startDate), ES[t.id]||0),
-    finish: cal.add(parseDate(project.startDate), EF[t.id]||0),
-    critical: (LS[t.id]??0)===(ES[t.id]??0)
-  }));
-
-  return {order, tasks: out, finishDays: projectFinish, warnings};
-}
-
 
 // --- Worker message handler ---
 self.onmessage = function(e) {


### PR DESCRIPTION
## Summary
- move CPM calculation into `assets/js/core/cpm.js`
- consume shared CPM engine from worker and main thread
- load CPM module in `index.html`

## Testing
- `node -e "require('./assets/js/core/date-cal.js');require('./assets/js/core/duration.js');require('./assets/js/core/deps.js');const {computeCPM}=require('./assets/js/core/cpm.js');console.log(typeof computeCPM);"`


------
https://chatgpt.com/codex/tasks/task_e_68a737a0eab88324b128bb3d043cc4b8