### PR TITLE
feat: separate project state store

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -216,85 +216,8 @@ function validateProject(project) {
 function adjustIncomingLags(task, delta){ const out=[]; for(const tok of (task.deps||[])){ const e=parseDepToken(tok); if(!e){ out.push(tok); continue; } if(e.type==='FS'||e.type==='SS'){ e.lag=(e.lag|0)+delta; out.push(stringifyDep(e)); } else { out.push(tok); } } return out; }
 
 // ----------------------------[ STATE MANAGEMENT ]----------------------------
-// Centralized state manager (SM) to handle application state, including undo/redo.
-// -------------------------------------------------------------------------------
-const SM=(function(){
-  let state=deepFreeze({ startDate: todayStr(), calendar:'workdays', holidays:[], tasks:[] });
-  let listeners=[]; let lastCPMWarns=[];
-  const undo=[]; const redo=[]; const MAX=100;
-  const BASE_KEY='hpc-project-baselines';
-  let baselines=[];
-  try{ baselines=JSON.parse(localStorage.getItem(BASE_KEY))||[]; }catch(e){ baselines=[]; }
-  function saveBaselines(){
-    try{ localStorage.setItem(BASE_KEY, JSON.stringify(baselines)); }
-    catch(e){ console.warn('Failed to save baselines', e); }
-  }
-  function get(){ return clone(state); }
-  function _apply(next){ state=deepFreeze(clone(next)); for(const fn of listeners){ try{ fn(get()); }catch(e){ console.warn(e); } } }
-
-  function updateUndoUI() {
-      const undoBtn = $('#btnUndo');
-      const redoBtn = $('#btnRedo');
-      if (undoBtn) {
-          const lastUndo = undo[undo.length - 1];
-          undoBtn.disabled = !canUndo();
-          undoBtn.title = lastUndo ? `Undo: ${lastUndo.name} (Ctrl+Z)` : 'Undo (Ctrl+Z)';
-      }
-      if (redoBtn) {
-          const lastRedo = redo[redo.length - 1];
-          redoBtn.disabled = !canRedo();
-          redoBtn.title = lastRedo ? `Redo: ${lastRedo.name} (Ctrl+Y)` : 'Redo (Ctrl+Y)';
-      }
-  }
-
-  function saveState(state) {
-    try {
-      const data = JSON.stringify(state);
-      localStorage.setItem('hpc-project-planner-data', data);
-      saveBaselines();
-      const lastSaved = new Date().toLocaleTimeString();
-      const lastSavedBadge = $('#lastSavedBadge');
-      if (lastSavedBadge) {
-        lastSavedBadge.innerHTML = `<span class="pill-icon" aria-hidden="true">💾</span> Saved: ${lastSaved}`;
-      }
-    } catch (e) {
-      console.warn('Failed to save state to localStorage', e);
-      const lastSavedBadge = $('#lastSavedBadge');
-      if (lastSavedBadge) {
-        lastSavedBadge.textContent = 'Save failed';
-      }
-    }
-  }
-  function set(next, opts={}){
-    const prev=get();
-    _apply(next);
-    if(opts.record!==false){
-      const actionName = opts.name || 'Unknown action';
-      undo.push({ state: prev, name: actionName });
-      if(undo.length>MAX) undo.shift();
-      redo.length=0;
-    }
-    window.dispatchEvent(new CustomEvent('state:changed', {detail:{sourceIds:opts.sourceIds||[]}}));
-    if (opts.noSave !== true) {
-      saveState(next);
-    }
-    updateUndoUI();
-  }
-  function setProjectProps(props, opts={}){ const cur=get(); Object.assign(cur, props); set(cur, opts); }
-  function addTasks(list, opts={}){ const cur=get(); const ids=new Set(cur.tasks.map(t=>t.id)); const add=list.map(t=>{ let id=t.id||uid('t'); while(ids.has(id)) id=uid('t'); ids.add(id); return {...t, id}; }); cur.tasks=cur.tasks.concat(add); set(cur, opts); }
-  function replaceTasks(tasks, opts={}){ const cur=get(); cur.tasks=tasks; set(cur, opts); }
-  function updateTask(id, patch, opts={}){ const cur=get(); const i=cur.tasks.findIndex(t=>t.id===id); if(i<0) return; cur.tasks=cur.tasks.slice(); cur.tasks[i]={...cur.tasks[i], ...patch}; set(cur,{sourceIds:[id], ...opts}); }
-  function onChange(fn){ listeners.push(fn); }
-  function setCPMWarnings(list){ lastCPMWarns = list||[]; }
-  function canUndo(){ return undo.length>0; } function canRedo(){ return redo.length>0; }
-  function undoOp(){ if(!canUndo()) return; const record=undo.pop(); const cur={state: get(), name: record.name}; redo.push(cur); _apply(record.state); updateUndoUI(); }
-  function redoOp(){ if(!canRedo()) return; const record=redo.pop(); const cur={state: get(), name: record.name}; undo.push(cur); _apply(record.state); updateUndoUI(); }
-  function listBaselines(){ return baselines.map(b=>({id:b.id,name:b.name,createdAt:b.createdAt})); }
-  function getBaseline(id){ const b=baselines.find(x=>x.id===id); return b? clone(b.projectSnapshot): null; }
-  function addBaseline(name){ const id=uid('b'); const projectSnapshot=get(); baselines.push({id,name,createdAt:new Date().toISOString(),projectSnapshot}); if(baselines.length>5) baselines=baselines.slice(-5); saveBaselines(); return id; }
-  function removeBaseline(id){ baselines=baselines.filter(b=>b.id!==id); saveBaselines(); }
-  return {get,set,setProjectProps,addTasks,replaceTasks,updateTask,onChange,setCPMWarnings,undo:undoOp,redo:redoOp,canUndo,canRedo,addBaseline,removeBaseline,getBaseline,listBaselines};
-})();
+// Centralized state manager (SM) for project data; provided by assets/js/state/store.js
+const SM = window.Store;
 
 // ----------------------------[ WARNING ENGINE ]----------------------------
 // Scans for potential issues and provides structured warnings.

--- a/assets/js/state/store.js
+++ b/assets/js/state/store.js
@@ -1,0 +1,96 @@
+(function(){
+  'use strict';
+
+  // Minimal utilities required by the store
+  const $ = (q, el=document) => el.querySelector(q);
+  function uid(prefix='t'){ return prefix+'_'+Math.random().toString(36).slice(2,8); }
+  function clone(o){ return JSON.parse(JSON.stringify(o)); }
+  function deepFreeze(o){ if(o && typeof o==='object' && !Object.isFrozen(o)){ Object.freeze(o); for(const k of Object.keys(o)){ deepFreeze(o[k]); } } return o; }
+  const todayStr = () => { const d = new Date(); return [d.getDate().toString().padStart(2,'0'), (d.getMonth()+1).toString().padStart(2,'0'), d.getFullYear()].join('-'); };
+
+  // Core state and undo/redo stacks
+  const MAX = 100;
+  const BASE_KEY = 'hpc-project-baselines';
+  let state = deepFreeze({ startDate: todayStr(), calendar:'workdays', holidays:[], tasks:[] });
+  let listeners = [];
+  let lastCPMWarns = [];
+  const undo = [];
+  const redo = [];
+  let baselines = [];
+  try { baselines = JSON.parse(localStorage.getItem(BASE_KEY)) || []; } catch(e) { baselines = []; }
+
+  function saveBaselines(){
+    try{ localStorage.setItem(BASE_KEY, JSON.stringify(baselines)); }
+    catch(e){ console.warn('Failed to save baselines', e); }
+  }
+
+  function get(){ return clone(state); }
+  function _apply(next){ state = deepFreeze(clone(next)); for(const fn of listeners){ try{ fn(get()); }catch(e){ console.warn(e); } } }
+
+  function updateUndoUI() {
+    const undoBtn = $('#btnUndo');
+    const redoBtn = $('#btnRedo');
+    if (undoBtn) {
+      const lastUndo = undo[undo.length - 1];
+      undoBtn.disabled = !canUndo();
+      undoBtn.title = lastUndo ? `Undo: ${lastUndo.name} (Ctrl+Z)` : 'Undo (Ctrl+Z)';
+    }
+    if (redoBtn) {
+      const lastRedo = redo[redo.length - 1];
+      redoBtn.disabled = !canRedo();
+      redoBtn.title = lastRedo ? `Redo: ${lastRedo.name} (Ctrl+Y)` : 'Redo (Ctrl+Y)';
+    }
+  }
+
+  function saveState(next){
+    try {
+      const data = JSON.stringify(next);
+      localStorage.setItem('hpc-project-planner-data', data);
+      saveBaselines();
+      const lastSaved = new Date().toLocaleTimeString();
+      const lastSavedBadge = $('#lastSavedBadge');
+      if (lastSavedBadge) {
+        lastSavedBadge.innerHTML = `<span class="pill-icon" aria-hidden="true">💾</span> Saved: ${lastSaved}`;
+      }
+    } catch (e) {
+      console.warn('Failed to save state to localStorage', e);
+      const lastSavedBadge = $('#lastSavedBadge');
+      if (lastSavedBadge) {
+        lastSavedBadge.textContent = 'Save failed';
+      }
+    }
+  }
+
+  function set(next, opts={}){
+    const prev = get();
+    _apply(next);
+    if(opts.record !== false){
+      const actionName = opts.name || 'Unknown action';
+      undo.push({ state: prev, name: actionName });
+      if(undo.length > MAX) undo.shift();
+      redo.length = 0;
+    }
+    window.dispatchEvent(new CustomEvent('state:changed', {detail:{sourceIds:opts.sourceIds||[]}}));
+    if (opts.noSave !== true) {
+      saveState(next);
+    }
+    updateUndoUI();
+  }
+
+  function setProjectProps(props, opts={}){ const cur=get(); Object.assign(cur, props); set(cur, opts); }
+  function addTasks(list, opts={}){ const cur=get(); const ids=new Set(cur.tasks.map(t=>t.id)); const add=list.map(t=>{ let id=t.id||uid('t'); while(ids.has(id)) id=uid('t'); ids.add(id); return {...t, id}; }); cur.tasks=cur.tasks.concat(add); set(cur, opts); }
+  function replaceTasks(tasks, opts={}){ const cur=get(); cur.tasks=tasks; set(cur, opts); }
+  function updateTask(id, patch, opts={}){ const cur=get(); const i=cur.tasks.findIndex(t=>t.id===id); if(i<0) return; cur.tasks=cur.tasks.slice(); cur.tasks[i]={...cur.tasks[i], ...patch}; set(cur,{sourceIds:[id], ...opts}); }
+  function onChange(fn){ listeners.push(fn); }
+  function setCPMWarnings(list){ lastCPMWarns = list||[]; }
+  function canUndo(){ return undo.length>0; }
+  function canRedo(){ return redo.length>0; }
+  function undoOp(){ if(!canUndo()) return; const record=undo.pop(); const cur={state: get(), name: record.name}; redo.push(cur); _apply(record.state); updateUndoUI(); }
+  function redoOp(){ if(!canRedo()) return; const record=redo.pop(); const cur={state: get(), name: record.name}; undo.push(cur); _apply(record.state); updateUndoUI(); }
+  function listBaselines(){ return baselines.map(b=>({id:b.id,name:b.name,createdAt:b.createdAt})); }
+  function getBaseline(id){ const b=baselines.find(x=>x.id===id); return b? clone(b.projectSnapshot): null; }
+  function addBaseline(name){ const id=uid('b'); const projectSnapshot=get(); baselines.push({id,name,createdAt:new Date().toISOString(),projectSnapshot}); if(baselines.length>5) baselines=baselines.slice(-5); saveBaselines(); return id; }
+  function removeBaseline(id){ baselines=baselines.filter(b=>b.id!==id); saveBaselines(); }
+
+  window.Store = {get,set,setProjectProps,addTasks,replaceTasks,updateTask,onChange,setCPMWarnings,undo:undoOp,redo:redoOp,canUndo,canRedo,addBaseline,removeBaseline,getBaseline,listBaselines};
+})();

--- a/index.html
+++ b/index.html
@@ -800,6 +800,7 @@ self.onmessage = function(e) {
   }
 };
 </script>
+<script defer src="assets/js/state/store.js"></script>
 <script defer src="assets/js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- extract project state, undo/redo, and baselines into new `assets/js/state/store.js`
- wire `app.js` to use external state store
- load store via new script tag in `index.html`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a81bd5e2f8832486eb63ed626d296b