### PR TITLE
refactor: introduce module bootstrap

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -28,7 +28,7 @@ function createCPMWorker(){
       return new Worker(url);
     }
   }
-  return new Worker('assets/js/cpm-worker.js');
+  return new Worker(new URL('./cpm-worker.js', import.meta.url));
 }
 
 
@@ -1522,7 +1522,7 @@ function newProject(){
 // ----------------------------[ APPLICATION BOOTSTRAP ]----------------------------
 // Main entry point of the application. Initializes the UI and sets up event listeners.
 // -------------------------------------------------------------------------------------
-window.addEventListener('DOMContentLoaded', ()=>{
+window.boot = ()=>{
   const ss = SettingsStore.get();
   rafBatch(()=>{
     if (UI_FLAGS.topSettingsToolbar) {
@@ -2004,7 +2004,7 @@ window.addEventListener('DOMContentLoaded', ()=>{
     console.error(err);
     const box=$('#fatal'); box.style.display='block'; box.textContent='Startup error:\n'+(err&&err.stack||String(err));
   }
-});
+};
 
 // ----------------------------[ DATA TEMPLATES ]----------------------------
 // Predefined project templates for various use cases (HPC, Software, Hardware).

--- a/assets/js/boot.js
+++ b/assets/js/boot.js
@@ -1,0 +1,7 @@
+import './app.js';
+
+window.addEventListener('DOMContentLoaded', () => {
+  if (typeof window.boot === 'function') {
+    window.boot();
+  }
+});

--- a/index.html
+++ b/index.html
@@ -801,6 +801,6 @@ self.onmessage = function(e) {
 };
 </script>
 <script defer src="assets/js/state/store.js"></script>
-<script defer src="assets/js/app.js"></script>
+<script type="module" src="assets/js/boot.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add ES module bootstrap entry `boot.js`
- load module entry from `index.html`
- resolve worker path relative to module using `import.meta.url`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8200db31483249ec5bbb076876451