### PR TITLE
feat: switch to ES module boot

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1522,7 +1522,7 @@ function newProject(){
 // ----------------------------[ APPLICATION BOOTSTRAP ]----------------------------
 // Main entry point of the application. Initializes the UI and sets up event listeners.
 // -------------------------------------------------------------------------------------
-window.addEventListener('DOMContentLoaded', ()=>{
+window.boot = ()=>{
   const ss = SettingsStore.get();
   rafBatch(()=>{
     if (UI_FLAGS.topSettingsToolbar) {
@@ -2238,9 +2238,10 @@ document.getElementById('btnToggleSidebar')?.addEventListener('click', (e)=>{
         }
       }
     });
-    observer.observe(bootElement, { attributes: true });
+  observer.observe(bootElement, { attributes: true });
   }
 
+};
 })();
 (function() {
   'use strict';

--- a/assets/js/boot.js
+++ b/assets/js/boot.js
@@ -1,0 +1,14 @@
+// Bootstraps the application using ES modules
+import './core/date-cal.js';
+import './core/duration.js';
+import './core/deps.js';
+import './core/cpm.js';
+import './state/store.js';
+import './app.js';
+
+window.addEventListener('DOMContentLoaded', () => {
+  if (typeof window.boot === 'function') {
+    window.boot();
+  }
+});
+

--- a/index.html
+++ b/index.html
@@ -559,10 +559,6 @@
     This app needs JavaScript enabled.
   </div>
 </noscript>
-<script defer src="assets/js/core/date-cal.js"></script>
-<script defer src="assets/js/core/duration.js"></script>
-<script defer src="assets/js/core/deps.js"></script>
-<script defer src="assets/js/core/cpm.js"></script>
 <script id="cpm-worker-src" type="text/plain">
 'use strict';
 
@@ -800,7 +796,6 @@ self.onmessage = function(e) {
   }
 };
 </script>
-<script defer src="assets/js/state/store.js"></script>
-<script defer src="assets/js/app.js"></script>
+<script type="module" src="assets/js/boot.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load app through new boot.js ES module
- expose bootstrap function and invoke via module
- update HTML entrypoint to use module script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8200db31483249ec5bbb076876451