### PR TITLE
feat: reduce label backgrounds

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -847,7 +847,7 @@
     font-size: 13px;
     fill: var(--ink);
     font-weight: 500;
-    /* Ensure bar labels are fill-only */
+    /* Reset label styling; specific effects added per-selector */
     filter: none;
     stroke: none;
     text-shadow: none;
@@ -868,6 +868,10 @@
     font-weight: 700;
     dominant-baseline: middle;
     text-rendering: optimizeLegibility;
+    paint-order: stroke fill;
+    stroke: var(--bg);
+    stroke-width: 3px;
+    stroke-linejoin: round;
   }
   
   /* Duration and percentage labels - make them more readable */
@@ -880,13 +884,6 @@
     fill: var(--ink);
   }
   
-  /* Task name background styling */
-  .taskNameBg{
-    opacity: 0.95;
-  }
-  html.dark-mode .taskNameBg {
-    opacity: 1;
-  }
   
   .gantt .handle{
     fill: #94a3b8;
@@ -1985,12 +1982,6 @@
   
   ::-webkit-scrollbar-thumb:hover {
     background: #94a3b8;
-  }
-
-  /* High-contrast task name chip + safe ellipsis */
-  .taskNameBg { fill: var(--panel); stroke: var(--line); opacity: 1; }
-  #timeline .gantt text.taskName {
-    font-size: 14px; font-weight: 700; fill: var(--ink);
   }
 
   /* Inside-bar labels: auto-hide when bar is narrow */

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -743,19 +743,6 @@ function renderGantt(project, cpm){ const svg=$('#gantt'); svg.innerHTML=''; con
       const left=document.createElementNS("http://www.w3.org/2000/svg","rect"); left.setAttribute("x",x-3); left.setAttribute("y",y); left.setAttribute("width",3); left.setAttribute("height",16); left.setAttribute("class","handle"); left.setAttribute("data-side","left"); bar.appendChild(left);
       const right=document.createElementNS("http://www.w3.org/2000/svg","rect"); right.setAttribute("x",x+w); right.setAttribute("y",y); right.setAttribute("width",3); right.setAttribute("height",16); right.setAttribute("class","handle"); right.setAttribute("data-side","right"); bar.appendChild(right);
     }
-    // Add background rectangle for task name readability
-    const nameBg=document.createElementNS("http://www.w3.org/2000/svg","rect");
-    const nameWidth = Math.max(80, (t.name||'').length * 8.5); // Estimate text width
-    nameBg.setAttribute("x", P - 10 - nameWidth);
-    nameBg.setAttribute("y", y - 4);
-    nameBg.setAttribute("width", nameWidth + 4);
-    nameBg.setAttribute("height", 24);
-    nameBg.setAttribute("fill", "var(--bg)");
-    nameBg.setAttribute("rx", "4");
-    nameBg.setAttribute("class", "taskNameBg");
-    nameBg.style.pointerEvents = 'none';
-    bar.appendChild(nameBg);
-
     const label=document.createElementNS("http://www.w3.org/2000/svg","text");
     label.setAttribute("class","label");
     label.setAttribute("x", P - 8);
@@ -789,9 +776,6 @@ function renderGantt(project, cpm){ const svg=$('#gantt'); svg.innerHTML=''; con
         tspan2.setAttribute("x", P-8);
         tspan2.setAttribute("dy", "1.2em");
         label.appendChild(tspan2);
-
-        nameBg.setAttribute('height', '40');
-        nameBg.setAttribute('y', y-6);
 
     } else {
         label.textContent = name;
@@ -2003,7 +1987,7 @@ window.addEventListener('DOMContentLoaded', ()=>{
       let css = '';
       const selectors = [
         '.gantt', '.bar', '.axis', '.label', '.critical', '.milestone',
-        '.progress', '.handle', '.groupHeader', '.groupLabel', '.taskNameBg',
+        '.progress', '.handle', '.groupHeader', '.groupLabel',
         '#timeline', '.stripes-bg', '.stripes-line'
       ];
       for (const sheet of document.styleSheets) {
@@ -2235,17 +2219,14 @@ function enhanceTimelineReadability() {
   // 1) Compute P, shift axis & bars if your renderer uses a constant P
   const P = computeLeftColumnWidth(svg, tasks); // e.g., 140..320
   // If your renderer uses a constant "P", update it here and re-render if needed.
-  // Otherwise, shift name texts and left chips based on P.
+  // Otherwise, shift name texts based on P.
   svg.style.setProperty('--left-col', P + 'px');
 
-  // 2) Fit task names + chip background
+  // 2) Fit task names within available left column
   svg.querySelectorAll('.gantt .bar').forEach(bar => {
     const nameText = bar.querySelector('text.label[text-anchor="end"], text.taskName');
-    const chip = bar.querySelector('rect.taskNameBg');
-    if (nameText && chip) {
-      // Max width for text inside the chip (chip width minus padding)
-      const chipWidth = Number(chip.getAttribute('width') || 0);
-      fitTaskName(nameText, chipWidth - 12);
+    if (nameText) {
+      fitTaskName(nameText, P - 20);
     }
   });
 


### PR DESCRIPTION
## Summary
- drop per-task name background rectangles
- use CSS paint-order to draw task labels with background stroke
- streamline name fitting logic after removing background chips

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a840f673b48324a673c4b3c92bf353