### PR TITLE
Use paint-order for task labels

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -849,7 +849,6 @@
     font-weight: 500;
     /* Ensure bar labels are fill-only */
     filter: none;
-    stroke: none;
     text-shadow: none;
   }
   
@@ -868,6 +867,10 @@
     font-weight: 700;
     dominant-baseline: middle;
     text-rendering: optimizeLegibility;
+    paint-order: stroke fill;
+    stroke: var(--bg);
+    stroke-width: 3px;
+    stroke-linejoin: round;
   }
   
   /* Duration and percentage labels - make them more readable */
@@ -878,14 +881,6 @@
   }
   .gantt .bar .label.duration-label {
     fill: var(--ink);
-  }
-  
-  /* Task name background styling */
-  .taskNameBg{
-    opacity: 0.95;
-  }
-  html.dark-mode .taskNameBg {
-    opacity: 1;
   }
   
   .gantt .handle{
@@ -1985,12 +1980,6 @@
   
   ::-webkit-scrollbar-thumb:hover {
     background: #94a3b8;
-  }
-
-  /* High-contrast task name chip + safe ellipsis */
-  .taskNameBg { fill: var(--panel); stroke: var(--line); opacity: 1; }
-  #timeline .gantt text.taskName {
-    font-size: 14px; font-weight: 700; fill: var(--ink);
   }
 
   /* Inside-bar labels: auto-hide when bar is narrow */

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -743,19 +743,6 @@ function renderGantt(project, cpm){ const svg=$('#gantt'); svg.innerHTML=''; con
       const left=document.createElementNS("http://www.w3.org/2000/svg","rect"); left.setAttribute("x",x-3); left.setAttribute("y",y); left.setAttribute("width",3); left.setAttribute("height",16); left.setAttribute("class","handle"); left.setAttribute("data-side","left"); bar.appendChild(left);
       const right=document.createElementNS("http://www.w3.org/2000/svg","rect"); right.setAttribute("x",x+w); right.setAttribute("y",y); right.setAttribute("width",3); right.setAttribute("height",16); right.setAttribute("class","handle"); right.setAttribute("data-side","right"); bar.appendChild(right);
     }
-    // Add background rectangle for task name readability
-    const nameBg=document.createElementNS("http://www.w3.org/2000/svg","rect");
-    const nameWidth = Math.max(80, (t.name||'').length * 8.5); // Estimate text width
-    nameBg.setAttribute("x", P - 10 - nameWidth);
-    nameBg.setAttribute("y", y - 4);
-    nameBg.setAttribute("width", nameWidth + 4);
-    nameBg.setAttribute("height", 24);
-    nameBg.setAttribute("fill", "var(--bg)");
-    nameBg.setAttribute("rx", "4");
-    nameBg.setAttribute("class", "taskNameBg");
-    nameBg.style.pointerEvents = 'none';
-    bar.appendChild(nameBg);
-
     const label=document.createElementNS("http://www.w3.org/2000/svg","text");
     label.setAttribute("class","label");
     label.setAttribute("x", P - 8);
@@ -789,9 +776,6 @@ function renderGantt(project, cpm){ const svg=$('#gantt'); svg.innerHTML=''; con
         tspan2.setAttribute("x", P-8);
         tspan2.setAttribute("dy", "1.2em");
         label.appendChild(tspan2);
-
-        nameBg.setAttribute('height', '40');
-        nameBg.setAttribute('y', y-6);
 
     } else {
         label.textContent = name;
@@ -2003,7 +1987,7 @@ window.addEventListener('DOMContentLoaded', ()=>{
       let css = '';
       const selectors = [
         '.gantt', '.bar', '.axis', '.label', '.critical', '.milestone',
-        '.progress', '.handle', '.groupHeader', '.groupLabel', '.taskNameBg',
+        '.progress', '.handle', '.groupHeader', '.groupLabel',
         '#timeline', '.stripes-bg', '.stripes-line'
       ];
       for (const sheet of document.styleSheets) {
@@ -2185,29 +2169,6 @@ function computeLeftColumnWidth(svg, tasks, min = 140, max = 320, pad = 18) {
   return Math.max(min, Math.min(max, Math.ceil(maxW + pad)));
 }
 
-/** Apply ellipsis + title tooltip when a name overflows the chip */
-function fitTaskName(svgTextEl, maxWidth) {
-  const full = svgTextEl.getAttribute('data-full') || svgTextEl.textContent;
-  svgTextEl.setAttribute('data-full', full);
-  svgTextEl.setAttribute('title', full);
-
-  // Quick exit if it already fits
-  svgTextEl.textContent = full;
-  if (svgTextEl.getComputedTextLength() <= maxWidth) return;
-
-  // Binary-search ellipsis
-  let lo = 0, hi = full.length, best = '';
-  while (lo <= hi) {
-    const mid = (lo + hi) >> 1;
-    const trial = full.slice(0, mid) + '…';
-    svgTextEl.textContent = trial;
-    if (svgTextEl.getComputedTextLength() <= maxWidth) {
-      best = trial; lo = mid + 1;
-    } else hi = mid - 1;
-  }
-  svgTextEl.textContent = best || '…';
-}
-
 /** Mark inside-bar labels as narrow when bar is small */
 function tagNarrowInbarLabels(svg, minWidth = 46) {
   svg.querySelectorAll('.gantt .bar').forEach(bar => {
@@ -2238,21 +2199,10 @@ function enhanceTimelineReadability() {
   // Otherwise, shift name texts and left chips based on P.
   svg.style.setProperty('--left-col', P + 'px');
 
-  // 2) Fit task names + chip background
-  svg.querySelectorAll('.gantt .bar').forEach(bar => {
-    const nameText = bar.querySelector('text.label[text-anchor="end"], text.taskName');
-    const chip = bar.querySelector('rect.taskNameBg');
-    if (nameText && chip) {
-      // Max width for text inside the chip (chip width minus padding)
-      const chipWidth = Number(chip.getAttribute('width') || 0);
-      fitTaskName(nameText, chipWidth - 12);
-    }
-  });
-
-  // 3) Hide cramped labels inside bars
+  // 2) Hide cramped labels inside bars
   tagNarrowInbarLabels(svg);
 
-  // 4) Re-run on next frame to catch zoom transforms
+  // 3) Re-run on next frame to catch zoom transforms
   requestAnimationFrame(() => tagNarrowInbarLabels(svg));
 }
 


### PR DESCRIPTION
## Summary
- Render task name labels without SVG rect backgrounds
- Stroke labels with `paint-order: stroke fill` to retain readability
- Drop unused chip/background code and helper

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a840f673b48324a673c4b3c92bf353