### PR TITLE
Add CSV import wizard for task creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,12 @@ The app is delivered as a static web page (index.html) with supporting assets un
 
 ### Export/Import
 
-You can export your project plan to a JSON file and import it back into the tool. This is useful for sharing your plan with others or for version control.
+You can export your project plan to a JSON file and import it back into the tool. CSV support is also available for moving task lists in and out of the planner.
 
-*   **Export:** Click the "Action" button in the header and select "Export JSON".
-*   **Import:** Click the "Action" button and select "Import JSON".
+*   **Export JSON:** Click the "Action" button in the header and select "Export JSON".
+*   **Import JSON:** Click the "Action" button and select "Import JSON".
+*   **Export CSV:** Click the "Export CSV" button in the toolbar to save task data as a comma-separated file.
+*   **Import CSV:** Click "Import CSV" and choose a file to map its columns and create tasks in the current project.
 
 ### Baselines
 

--- a/assets/js/import.js
+++ b/assets/js/import.js
@@ -1,0 +1,79 @@
+(function(){
+'use strict';
+
+function parseCSV(text){
+  const lines=text.trim().split(/\r?\n/);
+  return lines.map(line=>{
+    const cols=[]; let cur=''; let inQ=false;
+    for(let i=0;i<line.length;i++){
+      const ch=line[i];
+      if(ch==='"'){
+        if(inQ && line[i+1]==='"'){ cur+='"'; i++; }
+        else inQ=!inQ;
+      }else if(ch===',' && !inQ){ cols.push(cur); cur=''; }
+      else{ cur+=ch; }
+    }
+    cols.push(cur);
+    return cols.map(c=>c.replace(/^"|"$/g,'').replace(/""/g,'"'));
+  });
+}
+
+function mapColumns(headers){
+  const fields=[
+    {key:'id', label:'Task ID'},
+    {key:'name', label:'Name'},
+    {key:'duration', label:'Duration (days)'},
+    {key:'deps', label:'Dependencies'},
+    {key:'phase', label:'Phase'},
+    {key:'subsystem', label:'Subsystem'}
+  ];
+  const map={};
+  for(const f of fields){
+    let idx=headers.findIndex(h=>h.trim().toLowerCase()===f.label.toLowerCase().replace(/ \(.*\)/,''));
+    if(idx<0) idx=headers.findIndex(h=>h.trim().toLowerCase()===f.key.toLowerCase());
+    if(idx<0){
+      const answer=prompt(`Column for ${f.label}?\nHeaders: ${headers.join(', ')}`,'');
+      idx=headers.indexOf(answer);
+    }
+    map[f.key]=idx;
+  }
+  return map;
+}
+
+async function handleFile(file){
+  const text=await file.text();
+  const rows=parseCSV(text);
+  if(!rows.length) return;
+  const headers=rows[0];
+  const mapping=mapColumns(headers);
+  const tasks=[];
+  for(let i=1;i<rows.length;i++){
+    const r=rows[i];
+    if(r.every(c=>!c.trim())) continue;
+    const t={active:true};
+    if(mapping.id>=0) t.id=r[mapping.id];
+    if(mapping.name>=0) t.name=r[mapping.name];
+    if(mapping.duration>=0){ const d=parseDuration(r[mapping.duration]||''); t.duration=d.error?1:d.days; }
+    else t.duration=1;
+    if(mapping.deps>=0) t.deps=r[mapping.deps].split(/[\s;]+/).filter(Boolean);
+    if(mapping.phase>=0) t.phase=r[mapping.phase];
+    if(mapping.subsystem>=0) t.subsystem=r[mapping.subsystem];
+    tasks.push(t);
+  }
+  if(tasks.length){
+    SM.addTasks(tasks,{name:'Import CSV'});
+    if(typeof showToast==='function') showToast(`Imported ${tasks.length} tasks`);
+  }
+}
+
+const fileInput=document.getElementById('inputImportCSV');
+const btn=document.getElementById('btnImportCSV');
+if(btn && fileInput){
+  btn.addEventListener('click',()=>fileInput.click());
+  fileInput.addEventListener('change',()=>{
+    const f=fileInput.files[0];
+    if(f) handleFile(f);
+    fileInput.value='';
+  });
+}
+})();

--- a/index.html
+++ b/index.html
@@ -79,6 +79,11 @@
             <span class="btn-icon" aria-hidden="true">📊</span>
             <span class="sr-only">Export CSV</span>
           </button>
+          <button class="btn" id="btnImportCSV" aria-label="Import tasks from CSV" title="Import tasks from CSV">
+            <span class="btn-icon" aria-hidden="true">📥</span>
+            <span class="sr-only">Import CSV</span>
+          </button>
+          <input type="file" id="inputImportCSV" accept=".csv" style="display:none">
         </div>
       </div>
       <div class="toolbar-group">
@@ -802,5 +807,6 @@ self.onmessage = function(e) {
 </script>
 <script defer src="assets/js/state/store.js"></script>
 <script defer src="assets/js/app.js"></script>
+<script defer src="assets/js/import.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add hidden file input and Import CSV button to toolbar
- implement `assets/js/import.js` to parse CSV, map columns, and add tasks
- document CSV import/export in README

## Testing
- `node --check assets/js/import.js`
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8588805b08324a02203b85a322718