### PR TITLE
Restore legacy File/Tools toolbar

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -184,12 +184,20 @@
     justify-content: space-between;
     padding: var(--spacing-lg) var(--spacing-xl);
     background: var(--panel);
-    position: sticky; 
-    top: 0; 
-    z-index: 3; 
+    position: sticky;
+    top: 0;
+    z-index: 3;
     box-shadow: var(--shadow);
     border-bottom: 1px solid var(--line);
     backdrop-filter: blur(8px);
+  }
+
+  .legacy-header {
+    position: relative;
+    top: auto;
+    z-index: auto;
+    padding: var(--spacing-sm) var(--spacing-lg);
+    margin-bottom: var(--spacing-sm);
   }
   
   .header-left h1{

--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
     </defs>
   </svg>
   <a href="#main-content" class="skip-link">Skip to main content</a>
-  <header style="display:none">
+  <header class="legacy-header">
     <div class="header-left">
       <h1>
         <span class="title-icon" aria-hidden="true">📊</span>


### PR DESCRIPTION
## Summary
- Re-enable legacy File/Tools toolbar by removing inline `display:none` and attaching a reusable `legacy-header` class.
- Add `.legacy-header` styles for visibility and compact spacing so it coexists with the modern top bar.
- Confirm existing JavaScript bindings already handle all File/Tools actions.

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a865a4878c832498e3d68ef41b978f