### PR TITLE
Remove legacy left settings sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,6 @@ The baselines feature allows you to save a snapshot of your project plan and com
 
 We welcome your feedback! If you have any suggestions or find any bugs, please [open an issue on our GitHub page](https://github.com/user-repo/job-12-polish-docs/issues).
 
-## Top Settings Toolbar
+## Settings Toolbar
 
-The project settings sidebar has been moved to a toolbar in the header. A feature flag controls the layout:
-
-```
-window.ui.topSettingsToolbar = true; // default
-```
-
-When `true`, the sidebar is hidden and settings are accessible from the toolbar dropdowns. Add new settings items by editing `index.html` and wiring events in `assets/js/app.js`.
+Project settings are available from the dropdown menus in the header toolbar. Add new settings items by editing `index.html` and wiring events in `assets/js/app.js`.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -424,14 +424,6 @@
     margin: 0 auto;
   }
   
-  /* Collapsible sidebar */
-  body.sidebar-collapsed .layout { grid-template-columns: 0 1fr; }
-  body.sidebar-collapsed aside { display: none; }
-  @media (max-width: 1024px) {
-    /* auto-collapse under tablet width */
-    .layout { grid-template-columns: 1fr; }
-  }
-
   details > summary {
     list-style: none;
     cursor: pointer;
@@ -2014,18 +2006,10 @@
 
   .container.grid {
     display: grid;
-    grid-template-columns: 320px 1fr 280px;
+    grid-template-columns: 1fr 280px;
     gap: var(--spacing-lg);
     padding: var(--spacing-lg);
     align-items: start;
-  }
-
-  body.top-toolbar .container.grid {
-    grid-template-columns: 1fr 280px;
-  }
-
-  body.top-toolbar #left-panel {
-    display: none;
   }
 
   .panel {
@@ -2034,13 +2018,6 @@
     border-radius: var(--radius-lg);
     padding: var(--spacing-lg);
     box-shadow: var(--shadow-sm);
-  }
-
-  .panel.controls {
-    position: sticky;
-    top: 80px; /* Adjust based on header height */
-    height: calc(100vh - 100px);
-    overflow-y: auto;
   }
 
   #side .skeleton {
@@ -2053,7 +2030,7 @@
     .container.grid {
       grid-template-columns: 1fr;
     }
-    .panel.controls, #side {
+    #side {
       position: static;
       height: auto;
     }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -111,9 +111,6 @@ function setStyle(el, prop, val){ if(el) rafBatch(()=>{ el.style[prop] = val; })
 function setValue(el, val){ if(el) rafBatch(()=>{ el.value = val; }); }
 
 // ----------------------------[ SETTINGS STORE ]----------------------------
-const UI_FLAGS = { topSettingsToolbar: true };
-window.ui = UI_FLAGS;
-
 const SettingsStore = (function(){
   const state = {
     calendar: { startDate: todayStr(), mode: 'workdays', holidays: [] },
@@ -1241,7 +1238,7 @@ function renderContextPanel(selectedId) {
 
       <h4 style="font-size: 0.9em; text-transform: uppercase; color: var(--c-text-muted); border-bottom: 1px solid var(--c-border); padding-bottom: var(--space-1); margin-bottom: var(--space-3);">Actions</h4>
       <div class="button-group" style="display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-2);">
-        <button class="btn" id="ctx-btn-edit" title="Focus the editor fields for this task in the left sidebar">Edit</button>
+        <button class="btn" id="ctx-btn-edit" title="Focus the editor fields for this task">Edit</button>
         <button class="btn" id="ctx-btn-duplicate">Duplicate</button>
         <button class="btn" id="ctx-btn-toggle-active">${activeBtnText}</button>
         <button class="btn error" id="ctx-btn-delete">Delete</button>
@@ -1634,9 +1631,6 @@ function newProject(){
 window.addEventListener('DOMContentLoaded', ()=>{
   const ss = SettingsStore.get();
   rafBatch(()=>{
-    if (UI_FLAGS.topSettingsToolbar) {
-      document.body.classList.add('top-toolbar');
-    }
     setValue($('#slackThreshold'), ss.slackThreshold);
     setValue($('#filterText'), ss.filters.text);
     setValue($('#groupBy'), ss.filters.groupBy);
@@ -2255,12 +2249,6 @@ if (typeof _renderGanttOrig === 'function') {
   // Fallback if you don't have a render wrapper
   window.addEventListener('load', () => setTimeout(enhanceTimelineReadability, 0), { passive: true });
 }
-document.getElementById('btnToggleSidebar')?.addEventListener('click', (e)=>{
-  const on = !document.body.classList.contains('sidebar-collapsed');
-  document.body.classList.toggle('sidebar-collapsed', on);
-  e.currentTarget.setAttribute('aria-pressed', String(on));
-  setTimeout(()=> enhanceTimelineReadability(), 0); // reflow
-}, { passive: true });
 (function() {
   'use strict';
 

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
 <!--
   ID INVENTORY:
   stripes, critStripes, btnNew, btnLoad, btnSave, btnExportJSON, btnExportCSV, btnUndo, btnRedo,
-  btnPrint, btnGuide, btnToggleTheme, btnToggleSidebar, selBadge, scenarioBadge, lastSavedBadge,
+  btnPrint, btnGuide, btnToggleTheme, selBadge, scenarioBadge, lastSavedBadge,
   boot, fatal, appRoot, startDate, startDateHelp, calendarMode, calendarModeHelp, holidayInput,
   holidayInputHelp, slackThreshold, slackThresholdHelp, filterText, groupBy, groupByHelp,
   btnFilterClear, btnSelectFiltered, btnClearSel, btnSubAll, btnSubNone, subsysFilters,
@@ -109,7 +109,6 @@
             <span class="btn-icon" aria-hidden="true">🌙</span>
             <span class="sr-only">Theme</span>
           </button>
-          <button class="btn small" id="btnToggleSidebar" aria-pressed="false" aria-label="Toggle sidebar">☰</button>
         </div>
       </div>
     </div>
@@ -351,7 +350,6 @@
   </div>
   <div id="fatal"></div>
   <div class="container grid" id="layout" style="display:grid">
-    <aside class="panel controls" id="left-panel"></aside>
     <section class="panel" id="main">
         <div class="kpis">
             <div class="kpi card" id="kpiCritical">Critical: 12</div>
@@ -537,7 +535,7 @@
       </div>
       <div class="wizard-step" id="wz2" style="display:none" role="tabpanel" aria-labelledby="wz2Title">
         <h3 id="wz2Title">2) Import or insert a template</h3>
-        <p>Use <b>Open…</b> to load JSON/CSV or pick a library from the sidebar and click <b>Insert library</b>.</p>
+        <p>Use <b>Open…</b> to load JSON/CSV or pick a library from the dropdown menu and click <b>Insert library</b>.</p>
       </div>
       <div class="wizard-step" id="wz3" style="display:none" role="tabpanel" aria-labelledby="wz3Title">
         <h3 id="wz3Title">3) Wire dependencies</h3>


### PR DESCRIPTION
## Summary
- Drop obsolete left-panel markup and sidebar toggle button.
- Simplify layout to a two-column grid and clean up related CSS.
- Remove sidebar toggling code and feature flag references.
- Update docs to note settings are only in the header toolbar.

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8697f083c8324a23074d9af07ffe9