### PR TITLE
Remove legacy left settings sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,6 @@ The baselines feature allows you to save a snapshot of your project plan and com
 
 We welcome your feedback! If you have any suggestions or find any bugs, please [open an issue on our GitHub page](https://github.com/user-repo/job-12-polish-docs/issues).
 
-## Top Settings Toolbar
+## Settings Toolbar
 
-The project settings sidebar has been moved to a toolbar in the header. A feature flag controls the layout:
-
-```
-window.ui.topSettingsToolbar = true; // default
-```
-
-When `true`, the sidebar is hidden and settings are accessible from the toolbar dropdowns. Add new settings items by editing `index.html` and wiring events in `assets/js/app.js`.
+The project settings sidebar has been removed in favor of a toolbar in the header. All configuration options are accessible through the dropdown menus at the top. Add new settings items by editing `index.html` and wiring events in `assets/js/app.js`.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -424,11 +424,7 @@
     margin: 0 auto;
   }
   
-  /* Collapsible sidebar */
-  body.sidebar-collapsed .layout { grid-template-columns: 0 1fr; }
-  body.sidebar-collapsed aside { display: none; }
   @media (max-width: 1024px) {
-    /* auto-collapse under tablet width */
     .layout { grid-template-columns: 1fr; }
   }
 
@@ -2014,18 +2010,10 @@
 
   .container.grid {
     display: grid;
-    grid-template-columns: 320px 1fr 280px;
+    grid-template-columns: 1fr 280px;
     gap: var(--spacing-lg);
     padding: var(--spacing-lg);
     align-items: start;
-  }
-
-  body.top-toolbar .container.grid {
-    grid-template-columns: 1fr 280px;
-  }
-
-  body.top-toolbar #left-panel {
-    display: none;
   }
 
   .panel {
@@ -2034,13 +2022,6 @@
     border-radius: var(--radius-lg);
     padding: var(--spacing-lg);
     box-shadow: var(--shadow-sm);
-  }
-
-  .panel.controls {
-    position: sticky;
-    top: 80px; /* Adjust based on header height */
-    height: calc(100vh - 100px);
-    overflow-y: auto;
   }
 
   #side .skeleton {
@@ -2053,7 +2034,7 @@
     .container.grid {
       grid-template-columns: 1fr;
     }
-    .panel.controls, #side {
+    #side {
       position: static;
       height: auto;
     }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -111,8 +111,6 @@ function setStyle(el, prop, val){ if(el) rafBatch(()=>{ el.style[prop] = val; })
 function setValue(el, val){ if(el) rafBatch(()=>{ el.value = val; }); }
 
 // ----------------------------[ SETTINGS STORE ]----------------------------
-const UI_FLAGS = { topSettingsToolbar: true };
-window.ui = UI_FLAGS;
 
 const SettingsStore = (function(){
   const state = {
@@ -1634,9 +1632,6 @@ function newProject(){
 window.addEventListener('DOMContentLoaded', ()=>{
   const ss = SettingsStore.get();
   rafBatch(()=>{
-    if (UI_FLAGS.topSettingsToolbar) {
-      document.body.classList.add('top-toolbar');
-    }
     setValue($('#slackThreshold'), ss.slackThreshold);
     setValue($('#filterText'), ss.filters.text);
     setValue($('#groupBy'), ss.filters.groupBy);
@@ -2255,12 +2250,6 @@ if (typeof _renderGanttOrig === 'function') {
   // Fallback if you don't have a render wrapper
   window.addEventListener('load', () => setTimeout(enhanceTimelineReadability, 0), { passive: true });
 }
-document.getElementById('btnToggleSidebar')?.addEventListener('click', (e)=>{
-  const on = !document.body.classList.contains('sidebar-collapsed');
-  document.body.classList.toggle('sidebar-collapsed', on);
-  e.currentTarget.setAttribute('aria-pressed', String(on));
-  setTimeout(()=> enhanceTimelineReadability(), 0); // reflow
-}, { passive: true });
 (function() {
   'use strict';
 

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
 <!--
   ID INVENTORY:
   stripes, critStripes, btnNew, btnLoad, btnSave, btnExportJSON, btnExportCSV, btnUndo, btnRedo,
-  btnPrint, btnGuide, btnToggleTheme, btnToggleSidebar, selBadge, scenarioBadge, lastSavedBadge,
+  btnPrint, btnGuide, btnToggleTheme, selBadge, scenarioBadge, lastSavedBadge,
   boot, fatal, appRoot, startDate, startDateHelp, calendarMode, calendarModeHelp, holidayInput,
   holidayInputHelp, slackThreshold, slackThresholdHelp, filterText, groupBy, groupByHelp,
   btnFilterClear, btnSelectFiltered, btnClearSel, btnSubAll, btnSubNone, subsysFilters,
@@ -109,7 +109,6 @@
             <span class="btn-icon" aria-hidden="true">🌙</span>
             <span class="sr-only">Theme</span>
           </button>
-          <button class="btn small" id="btnToggleSidebar" aria-pressed="false" aria-label="Toggle sidebar">☰</button>
         </div>
       </div>
     </div>
@@ -351,7 +350,6 @@
   </div>
   <div id="fatal"></div>
   <div class="container grid" id="layout" style="display:grid">
-    <aside class="panel controls" id="left-panel"></aside>
     <section class="panel" id="main">
         <div class="kpis">
             <div class="kpi card" id="kpiCritical">Critical: 12</div>


### PR DESCRIPTION
## Summary
- drop the unused left settings sidebar and rely solely on the header dropdowns
- simplify layout CSS to a two-column grid and clean related rules
- remove feature flag and sidebar toggle code

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8697f083c8324a23074d9af07ffe9