### PR TITLE
Remove unused left settings sidebar

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -414,23 +414,6 @@
     color: var(--muted);
   }
   
-  /* Enhanced layout */
-  .layout{
-    display: grid;
-    grid-template-columns: auto 1fr;
-    gap: var(--spacing-xl);
-    padding: var(--spacing-xl);
-    max-width: 1920px;
-    margin: 0 auto;
-  }
-  
-  /* Collapsible sidebar */
-  body.sidebar-collapsed .layout { grid-template-columns: 0 1fr; }
-  body.sidebar-collapsed aside { display: none; }
-  @media (max-width: 1024px) {
-    /* auto-collapse under tablet width */
-    .layout { grid-template-columns: 1fr; }
-  }
 
   details > summary {
     list-style: none;
@@ -2014,18 +1997,10 @@
 
   .container.grid {
     display: grid;
-    grid-template-columns: 320px 1fr 280px;
+    grid-template-columns: 1fr 280px;
     gap: var(--spacing-lg);
     padding: var(--spacing-lg);
     align-items: start;
-  }
-
-  body.top-toolbar .container.grid {
-    grid-template-columns: 1fr 280px;
-  }
-
-  body.top-toolbar #left-panel {
-    display: none;
   }
 
   .panel {
@@ -2034,13 +2009,6 @@
     border-radius: var(--radius-lg);
     padding: var(--spacing-lg);
     box-shadow: var(--shadow-sm);
-  }
-
-  .panel.controls {
-    position: sticky;
-    top: 80px; /* Adjust based on header height */
-    height: calc(100vh - 100px);
-    overflow-y: auto;
   }
 
   #side .skeleton {
@@ -2053,7 +2021,7 @@
     .container.grid {
       grid-template-columns: 1fr;
     }
-    .panel.controls, #side {
+    #side {
       position: static;
       height: auto;
     }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -111,8 +111,7 @@ function setStyle(el, prop, val){ if(el) rafBatch(()=>{ el.style[prop] = val; })
 function setValue(el, val){ if(el) rafBatch(()=>{ el.value = val; }); }
 
 // ----------------------------[ SETTINGS STORE ]----------------------------
-const UI_FLAGS = { topSettingsToolbar: true };
-window.ui = UI_FLAGS;
+window.ui = {};
 
 const SettingsStore = (function(){
   const state = {
@@ -1241,7 +1240,7 @@ function renderContextPanel(selectedId) {
 
       <h4 style="font-size: 0.9em; text-transform: uppercase; color: var(--c-text-muted); border-bottom: 1px solid var(--c-border); padding-bottom: var(--space-1); margin-bottom: var(--space-3);">Actions</h4>
       <div class="button-group" style="display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-2);">
-        <button class="btn" id="ctx-btn-edit" title="Focus the editor fields for this task in the left sidebar">Edit</button>
+        <button class="btn" id="ctx-btn-edit" title="Focus the editor fields for this task">Edit</button>
         <button class="btn" id="ctx-btn-duplicate">Duplicate</button>
         <button class="btn" id="ctx-btn-toggle-active">${activeBtnText}</button>
         <button class="btn error" id="ctx-btn-delete">Delete</button>
@@ -1634,9 +1633,6 @@ function newProject(){
 window.addEventListener('DOMContentLoaded', ()=>{
   const ss = SettingsStore.get();
   rafBatch(()=>{
-    if (UI_FLAGS.topSettingsToolbar) {
-      document.body.classList.add('top-toolbar');
-    }
     setValue($('#slackThreshold'), ss.slackThreshold);
     setValue($('#filterText'), ss.filters.text);
     setValue($('#groupBy'), ss.filters.groupBy);
@@ -2255,12 +2251,6 @@ if (typeof _renderGanttOrig === 'function') {
   // Fallback if you don't have a render wrapper
   window.addEventListener('load', () => setTimeout(enhanceTimelineReadability, 0), { passive: true });
 }
-document.getElementById('btnToggleSidebar')?.addEventListener('click', (e)=>{
-  const on = !document.body.classList.contains('sidebar-collapsed');
-  document.body.classList.toggle('sidebar-collapsed', on);
-  e.currentTarget.setAttribute('aria-pressed', String(on));
-  setTimeout(()=> enhanceTimelineReadability(), 0); // reflow
-}, { passive: true });
 (function() {
   'use strict';
 

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
 <!--
   ID INVENTORY:
   stripes, critStripes, btnNew, btnLoad, btnSave, btnExportJSON, btnExportCSV, btnUndo, btnRedo,
-  btnPrint, btnGuide, btnToggleTheme, btnToggleSidebar, selBadge, scenarioBadge, lastSavedBadge,
+  btnPrint, btnGuide, btnToggleTheme, selBadge, scenarioBadge, lastSavedBadge,
   boot, fatal, appRoot, startDate, startDateHelp, calendarMode, calendarModeHelp, holidayInput,
   holidayInputHelp, slackThreshold, slackThresholdHelp, filterText, groupBy, groupByHelp,
   btnFilterClear, btnSelectFiltered, btnClearSel, btnSubAll, btnSubNone, subsysFilters,
@@ -109,7 +109,6 @@
             <span class="btn-icon" aria-hidden="true">🌙</span>
             <span class="sr-only">Theme</span>
           </button>
-          <button class="btn small" id="btnToggleSidebar" aria-pressed="false" aria-label="Toggle sidebar">☰</button>
         </div>
       </div>
     </div>
@@ -351,7 +350,6 @@
   </div>
   <div id="fatal"></div>
   <div class="container grid" id="layout" style="display:grid">
-    <aside class="panel controls" id="left-panel"></aside>
     <section class="panel" id="main">
         <div class="kpis">
             <div class="kpi card" id="kpiCritical">Critical: 12</div>


### PR DESCRIPTION
## Summary
- delete legacy left settings sidebar and toggle control
- simplify grid to two columns for main workspace and context panel
- drop sidebar feature flag and related code

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8697f083c8324a23074d9af07ffe9