### PR TITLE
Ensure toolbar stacking and spacing

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -194,10 +194,9 @@
 
   .legacy-header {
     position: relative;
-    top: auto;
-    z-index: auto;
+    z-index: 10;
     padding: var(--spacing-sm) var(--spacing-lg);
-    margin-bottom: var(--spacing-sm);
+    margin-bottom: 4px;
   }
   
   .header-left h1{
@@ -222,6 +221,11 @@
     gap: var(--spacing-sm);
     flex-wrap: wrap;
     justify-content: center;
+  }
+
+  .top-toolbar {
+    position: relative;
+    z-index: 9;
   }
 
   .toolbar-item {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2348,6 +2348,7 @@ if (typeof _renderGanttOrig === 'function') {
   }, { passive: true });
 
   document.addEventListener('click', (e) => {
+    if (e.target.closest('.legacy-header')) return;
     const isExpanded = actionButton.getAttribute('aria-expanded') === 'true';
     if (isExpanded && !actionMenu.contains(e.target) && !actionButton.contains(e.target)) {
       closeMenu();
@@ -2406,6 +2407,7 @@ if (typeof _renderGanttOrig === 'function') {
 
   // Global keydown for Escape, as menu may not have focus
   document.addEventListener('keydown', (e) => {
+    if (e.target.closest('.legacy-header')) return;
     if (e.key === 'Escape' && actionMenu.classList.contains('open')) {
       closeMenu();
     }

--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@
       <h1>HPC/AI Planner</h1>
     </div>
     <div class="header-center">
-      <div class="toolbar" id="top-toolbar">
+      <div class="toolbar top-toolbar" id="top-toolbar">
         <div class="toolbar-item">
           <button class="btn" id="btn-project-calendar" aria-haspopup="true" aria-expanded="false">Project Calendar</button>
           <div id="menu-project-calendar" class="action-menu" role="menu" style="display:none">


### PR DESCRIPTION
## Summary
- set legacy file/tools bar above the new toolbar with z-index and margin spacing
- add top-toolbar class for dropdown row with lower z-index
- ignore legacy header in dropdown close handlers

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a86f0becc88324b1a314b9ab12a6a5