### PR TITLE
Fix toolbar stacking order and spacing

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -195,9 +195,9 @@
   .legacy-header {
     position: relative;
     top: auto;
-    z-index: auto;
+    z-index: 10;
     padding: var(--spacing-sm) var(--spacing-lg);
-    margin-bottom: var(--spacing-sm);
+    margin-bottom: 4px;
   }
   
   .header-left h1{
@@ -217,11 +217,13 @@
     justify-content: center;
   }
 
-  #top-toolbar {
+  .top-toolbar {
     display: flex;
     gap: var(--spacing-sm);
     flex-wrap: wrap;
     justify-content: center;
+    position: relative;
+    z-index: 9;
   }
 
   .toolbar-item {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2348,6 +2348,7 @@ if (typeof _renderGanttOrig === 'function') {
   }, { passive: true });
 
   document.addEventListener('click', (e) => {
+    if (e.target.closest('.legacy-header')) return;
     const isExpanded = actionButton.getAttribute('aria-expanded') === 'true';
     if (isExpanded && !actionMenu.contains(e.target) && !actionButton.contains(e.target)) {
       closeMenu();
@@ -2406,6 +2407,7 @@ if (typeof _renderGanttOrig === 'function') {
 
   // Global keydown for Escape, as menu may not have focus
   document.addEventListener('keydown', (e) => {
+    if (e.target.closest('.legacy-header')) return;
     if (e.key === 'Escape' && actionMenu.classList.contains('open')) {
       closeMenu();
     }
@@ -2441,7 +2443,7 @@ if (typeof _renderGanttOrig === 'function') {
       setTimeout(()=>{ if(!menu.classList.contains('open')) menu.style.display='none'; },150);
     }
     btn.addEventListener('click',()=>{ const exp=btn.getAttribute('aria-expanded')==='true'; exp?closeMenu():openMenu(); }, { passive: true });
-    document.addEventListener('click',(e)=>{ const exp=btn.getAttribute('aria-expanded')==='true'; if(exp && !menu.contains(e.target) && !btn.contains(e.target)) closeMenu(); }, { passive: true });
+    document.addEventListener('click',(e)=>{ if(e.target.closest('.legacy-header')) return; const exp=btn.getAttribute('aria-expanded')==='true'; if(exp && !menu.contains(e.target) && !btn.contains(e.target)) closeMenu(); }, { passive: true });
     menu.addEventListener('keydown',(e)=>{ if(e.key==='Escape'){ closeMenu(); return; } if(e.key==='Tab'){ const items=getItems(); if(items.length){ const first=items[0]; const last=items[items.length-1]; if(e.shiftKey && document.activeElement===first){ e.preventDefault(); last.focus(); } else if(!e.shiftKey && document.activeElement===last){ e.preventDefault(); first.focus(); } } }});
   }
   setupDropdown('btn-project-calendar','menu-project-calendar');

--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@
       <h1>HPC/AI Planner</h1>
     </div>
     <div class="header-center">
-      <div class="toolbar" id="top-toolbar">
+      <div class="toolbar top-toolbar" id="top-toolbar">
         <div class="toolbar-item">
           <button class="btn" id="btn-project-calendar" aria-haspopup="true" aria-expanded="false">Project Calendar</button>
           <div id="menu-project-calendar" class="action-menu" role="menu" style="display:none">


### PR DESCRIPTION
## Summary
- Set legacy header above dropdown toolbar and add spacing
- Ensure dropdown toolbar sits below with its own stacking context
- Ignore legacy header in global dropdown close handlers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a86f0becc88324b1a314b9ab12a6a5