### PR TITLE
Prevent legacy header from overlapping top dropdown

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -194,10 +194,9 @@
 
   .legacy-header {
     position: relative;
-    top: auto;
-    z-index: auto;
+    z-index: 10;
     padding: var(--spacing-sm) var(--spacing-lg);
-    margin-bottom: var(--spacing-sm);
+    margin-bottom: 4px;
   }
   
   .header-left h1{
@@ -215,6 +214,11 @@
     flex: 1;
     display: flex;
     justify-content: center;
+  }
+
+  .top-toolbar {
+    position: relative;
+    z-index: 9;
   }
 
   #top-toolbar {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2424,6 +2424,7 @@ if (typeof _renderGanttOrig === 'function') {
 (function(){
   'use strict';
   let activeDropdownClose = null;
+  const legacyHeader = document.querySelector('.legacy-header');
   function setupDropdown(buttonId, menuId, onOpen){
     const btn=document.getElementById(buttonId);
     const menu=document.getElementById(menuId);
@@ -2441,7 +2442,7 @@ if (typeof _renderGanttOrig === 'function') {
       setTimeout(()=>{ if(!menu.classList.contains('open')) menu.style.display='none'; },150);
     }
     btn.addEventListener('click',()=>{ const exp=btn.getAttribute('aria-expanded')==='true'; exp?closeMenu():openMenu(); }, { passive: true });
-    document.addEventListener('click',(e)=>{ const exp=btn.getAttribute('aria-expanded')==='true'; if(exp && !menu.contains(e.target) && !btn.contains(e.target)) closeMenu(); }, { passive: true });
+    document.addEventListener('click',(e)=>{ if(legacyHeader && legacyHeader.contains(e.target)) return; const exp=btn.getAttribute('aria-expanded')==='true'; if(exp && !menu.contains(e.target) && !btn.contains(e.target)) closeMenu(); }, { passive: true });
     menu.addEventListener('keydown',(e)=>{ if(e.key==='Escape'){ closeMenu(); return; } if(e.key==='Tab'){ const items=getItems(); if(items.length){ const first=items[0]; const last=items[items.length-1]; if(e.shiftKey && document.activeElement===first){ e.preventDefault(); last.focus(); } else if(!e.shiftKey && document.activeElement===last){ e.preventDefault(); first.focus(); } } }});
   }
   setupDropdown('btn-project-calendar','menu-project-calendar');
@@ -2452,4 +2453,6 @@ if (typeof _renderGanttOrig === 'function') {
   setupDropdown('btn-template','menu-template');
   setupDropdown('btn-validation','menu-validation');
   setupDropdown('btn-legend','menu-legend');
+
+  document.addEventListener('keydown',(e)=>{ if(e.key==='Escape'){ const activeEl=document.activeElement; if(activeEl && legacyHeader && legacyHeader.contains(activeEl)) return; activeDropdownClose?.(); } }, { passive: true });
 })();

--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@
       <h1>HPC/AI Planner</h1>
     </div>
     <div class="header-center">
-      <div class="toolbar" id="top-toolbar">
+      <div class="toolbar top-toolbar" id="top-toolbar">
         <div class="toolbar-item">
           <button class="btn" id="btn-project-calendar" aria-haspopup="true" aria-expanded="false">Project Calendar</button>
           <div id="menu-project-calendar" class="action-menu" role="menu" style="display:none">


### PR DESCRIPTION
## Summary
- Add `top-toolbar` class in markup and CSS to control stacking order and spacing
- Ensure legacy header sits above dropdown toolbar via explicit z-index and margin
- Ignore legacy header in dropdown click-outside and Escape-close handlers

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a86f0becc88324b1a314b9ab12a6a5