### PR TITLE
Ensure legacy header and dropdown toolbar don't overlap

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -195,9 +195,9 @@
   .legacy-header {
     position: relative;
     top: auto;
-    z-index: auto;
+    z-index: 10;
     padding: var(--spacing-sm) var(--spacing-lg);
-    margin-bottom: var(--spacing-sm);
+    margin-bottom: 4px;
   }
   
   .header-left h1{
@@ -215,6 +215,11 @@
     flex: 1;
     display: flex;
     justify-content: center;
+  }
+
+  .top-toolbar {
+    position: relative;
+    z-index: 9;
   }
 
   #top-toolbar {
@@ -2082,7 +2087,7 @@
     padding: var(--space-3) var(--space-4);
     position: sticky;
     top: 0;
-    z-index: 10;
+    z-index: 9;
   }
 
   .grid {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2349,7 +2349,12 @@ if (typeof _renderGanttOrig === 'function') {
 
   document.addEventListener('click', (e) => {
     const isExpanded = actionButton.getAttribute('aria-expanded') === 'true';
-    if (isExpanded && !actionMenu.contains(e.target) && !actionButton.contains(e.target)) {
+    if (
+      isExpanded &&
+      !actionMenu.contains(e.target) &&
+      !actionButton.contains(e.target) &&
+      !e.target.closest('.legacy-header')
+    ) {
       closeMenu();
     }
   }, { passive: true });
@@ -2441,7 +2446,7 @@ if (typeof _renderGanttOrig === 'function') {
       setTimeout(()=>{ if(!menu.classList.contains('open')) menu.style.display='none'; },150);
     }
     btn.addEventListener('click',()=>{ const exp=btn.getAttribute('aria-expanded')==='true'; exp?closeMenu():openMenu(); }, { passive: true });
-    document.addEventListener('click',(e)=>{ const exp=btn.getAttribute('aria-expanded')==='true'; if(exp && !menu.contains(e.target) && !btn.contains(e.target)) closeMenu(); }, { passive: true });
+    document.addEventListener('click',(e)=>{ const exp=btn.getAttribute('aria-expanded')==='true'; if(exp && !menu.contains(e.target) && !btn.contains(e.target) && !e.target.closest('.legacy-header')) closeMenu(); }, { passive: true });
     menu.addEventListener('keydown',(e)=>{ if(e.key==='Escape'){ closeMenu(); return; } if(e.key==='Tab'){ const items=getItems(); if(items.length){ const first=items[0]; const last=items[items.length-1]; if(e.shiftKey && document.activeElement===first){ e.preventDefault(); last.focus(); } else if(!e.shiftKey && document.activeElement===last){ e.preventDefault(); first.focus(); } } }});
   }
   setupDropdown('btn-project-calendar','menu-project-calendar');

--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@
       <h1>HPC/AI Planner</h1>
     </div>
     <div class="header-center">
-      <div class="toolbar" id="top-toolbar">
+      <div class="toolbar top-toolbar" id="top-toolbar">
         <div class="toolbar-item">
           <button class="btn" id="btn-project-calendar" aria-haspopup="true" aria-expanded="false">Project Calendar</button>
           <div id="menu-project-calendar" class="action-menu" role="menu" style="display:none">


### PR DESCRIPTION
## Summary
- Elevate legacy header above new toolbar with explicit z-indexes and margin spacing
- Introduce `top-toolbar` class and stacking context for dropdown row
- Prevent dropdown close handlers from consuming clicks on legacy bar

## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a86f0becc88324b1a314b9ab12a6a5