### PR TITLE
chore: remove obsolete sidebar remnants

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,3 @@ The baselines feature allows you to save a snapshot of your project plan and com
 
 We welcome your feedback! If you have any suggestions or find any bugs, please [open an issue on our GitHub page](https://github.com/user-repo/job-12-polish-docs/issues).
 
-## Top Settings Toolbar
-
-The project settings sidebar has been moved to a toolbar in the header. A feature flag controls the layout:
-
-```
-window.ui.topSettingsToolbar = true; // default
-```
-
-When `true`, the sidebar is hidden and settings are accessible from the toolbar dropdowns. Add new settings items by editing `index.html` and wiring events in `assets/js/app.js`.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -428,7 +428,7 @@
     display: none;
   }
 
-  /* Enhanced sidebar */
+  /* Context panel */
   aside{
     background: var(--panel);
     border: 1px solid var(--line);
@@ -1696,7 +1696,7 @@
     aside {
       position: static;
       height: auto;
-      max-height: 50vh; /* Allow more space for sidebar on tablet */
+      max-height: 50vh; /* Allow more space for context panel on tablet */
     }
     
     .focus .cards {
@@ -2103,13 +2103,6 @@
     box-shadow: var(--shadow-sm);
   }
 
-  .controls {
-    position: sticky;
-    top: 80px; /* Assuming header height */
-    height: calc(100vh - 100px);
-    overflow-y: auto;
-  }
-
   .row {
     display: flex;
     align-items: center;
@@ -2298,7 +2291,7 @@
       -webkit-print-color-adjust: exact;
       print-color-adjust: exact;
     }
-    .app-header, .controls, #side {
+    .app-header, #side {
       display: none !important;
     }
     .grid {

--- a/index.html
+++ b/index.html
@@ -534,7 +534,7 @@
       </div>
       <div class="wizard-step" id="wz2" style="display:none" role="tabpanel" aria-labelledby="wz2Title">
         <h3 id="wz2Title">2) Import or insert a template</h3>
-        <p>Use <b>Open…</b> to load JSON/CSV or pick a library from the sidebar and click <b>Insert library</b>.</p>
+        <p>Use <b>Open…</b> to load JSON/CSV or click <b>Insert library</b>.</p>
       </div>
       <div class="wizard-step" id="wz3" style="display:none" role="tabpanel" aria-labelledby="wz3Title">
         <h3 id="wz3Title">3) Wire dependencies</h3>


### PR DESCRIPTION
## Summary
- drop mention of old top settings toolbar feature flag
- strip unused `.controls` styles and sidebar comments
- clean wizard copy that referenced a removed sidebar

## Testing
- `npm test` *(fails: no package.json)*
- `node --check assets/js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8735b066883248558e511cab2b1dd