### PR TITLE
chore: remove legacy sidebar and header remnants

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,3 @@ The baselines feature allows you to save a snapshot of your project plan and com
 
 We welcome your feedback! If you have any suggestions or find any bugs, please [open an issue on our GitHub page](https://github.com/user-repo/job-12-polish-docs/issues).
 
-## Top Settings Toolbar
-
-The project settings sidebar has been moved to a toolbar in the header. A feature flag controls the layout:
-
-```
-window.ui.topSettingsToolbar = true; // default
-```
-
-When `true`, the sidebar is hidden and settings are accessible from the toolbar dropdowns. Add new settings items by editing `index.html` and wiring events in `assets/js/app.js`.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -192,14 +192,6 @@
     backdrop-filter: blur(8px);
   }
 
-  .legacy-header {
-    position: relative;
-    top: auto;
-    z-index: 10;
-    padding: var(--spacing-sm) var(--spacing-lg);
-    margin-bottom: 4px;
-  }
-  
   .header-left h1{
     font-size: var(--font-size-xl);
     margin: 0;
@@ -233,80 +225,11 @@
     position: relative;
   }
   
-  .title-icon {
-    font-size: 1.5em;
-    opacity: 0.8;
-  }
-  
-  .subtitle {
-    color: var(--muted);
-    font-weight: 400;
-    font-size: 0.7em;
-    margin-left: var(--spacing-sm);
-  }
-  
-    .toolbar-group {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-sm);
-  }
-
-  .toolbar-heading {
-    font-size: var(--font-size-sm);
-    color: var(--muted);
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    margin: 0;
-    padding: 0;
-    text-align: center;
-    font-weight: 600;
-  }
-  
-  .button-group {
-    display: flex;
-    gap: var(--spacing-md);
-    align-items: center;
-  }
-  
-  
   .btn-icon {
     font-size: 0.9em;
     margin-right: var(--spacing-xs);
   }
-  
-  
-  .status-indicators {
-    display: flex;
-    gap: var(--spacing-sm);
-    margin-bottom: var(--spacing-sm);
-  }
-  
-  .status-pill {
-    background: rgba(49, 130, 206, 0.1);
-    border-color: var(--accent-light);
-    color: var(--accent-dark);
-    font-weight: 600;
-  }
-  
-  .feature-pill {
-    background: rgba(56, 161, 105, 0.1);
-    border-color: var(--ok);
-    color: var(--ok);
-    font-size: 0.8em;
-  }
-  
-  .pill-icon {
-    margin-right: var(--spacing-xs);
-    font-size: 0.9em;
-  }
-  
-  header .right{
-    display: flex; 
-    flex-direction: column;
-    gap: var(--spacing-sm);
-    align-items: flex-end;
-  }
-  
+
   /* Enhanced button styles */
   .btn{
     background: var(--panel);
@@ -1675,24 +1598,12 @@
   
   /* Responsive improvements */
   @media (max-width: 1200px) {
-    .layout {
-      grid-template-columns: 350px 1fr;
-      gap: var(--spacing-lg);
-      padding: var(--spacing-lg);
-    }
-    
     .focus .cards {
       grid-template-columns: repeat(2, 1fr);
     }
   }
-  
+
   @media (max-width: 900px) {
-    .layout {
-      grid-template-columns: 1fr;
-      gap: var(--spacing-md);
-      padding: var(--spacing-md);
-    }
-    
     aside {
       position: static;
       height: auto;
@@ -1715,23 +1626,6 @@
       gap: var(--spacing-md);
     }
 
-    .toolbar-group {
-      align-items: stretch;
-    }
-
-    .button-group {
-      flex-wrap: wrap;
-      justify-content: center;
-    }
-    
-    header .right {
-      margin-left: 0;
-      width: 100%;
-      justify-content: center;
-      margin-top: var(--spacing-sm);
-      align-items: center;
-    }
-    
     /* Enhanced mobile navigation */
     .legend {
       flex-direction: column;
@@ -1773,14 +1667,10 @@
 
   /* Enhanced large screen optimizations */
   @media (min-width: 1025px) {
-    .layout {
-      grid-template-columns: 350px 1fr;
-    }
-    
     .cards {
       grid-template-columns: repeat(4, 1fr);
     }
-    
+
     .subsys {
       grid-template-columns: repeat(3, 1fr);
     }
@@ -1793,11 +1683,6 @@
       color: black !important;
       box-shadow: none !important;
       text-shadow: none !important;
-    }
-    
-    .layout {
-      grid-template-columns: 1fr;
-      gap: 0;
     }
     
     aside {
@@ -1935,10 +1820,6 @@
   }
   
   /* Apply animations to key elements */
-  .layout {
-    animation: fadeIn 0.6s ease-out;
-  }
-  
   .card, .metric-card, .issue {
     animation: fadeIn 0.4s ease-out;
   }

--- a/assets/js/import.js
+++ b/assets/js/import.js
@@ -83,9 +83,4 @@
     fileInput.click();
   }
 
-  document.addEventListener('DOMContentLoaded', () => {
-    const btn = $('#btnImportCSV');
-    if(btn) btn.addEventListener('click', startImport);
-  });
-
 })();

--- a/assets/js/state/store.js
+++ b/assets/js/state/store.js
@@ -51,20 +51,7 @@ const SM = (function(){
     }
   }
 
-  function updateUndoUI(){
-    const undoBtn = $('#btnUndo');
-    const redoBtn = $('#btnRedo');
-    if(undoBtn){
-      const lastUndo = undo[undo.length - 1];
-      undoBtn.disabled = !canUndo();
-      undoBtn.title = lastUndo ? `Undo: ${lastUndo.name} (Ctrl+Z)` : 'Undo (Ctrl+Z)';
-    }
-    if(redoBtn){
-      const lastRedo = redo[redo.length - 1];
-      redoBtn.disabled = !canRedo();
-      redoBtn.title = lastRedo ? `Redo: ${lastRedo.name} (Ctrl+Y)` : 'Redo (Ctrl+Y)';
-    }
-  }
+  function updateUndoUI(){}
 
   function saveState(state){
     try{
@@ -72,14 +59,8 @@ const SM = (function(){
       localStorage.setItem('hpc-project-planner-data', data);
       saveBaselines();
       const lastSaved = new Date().toLocaleTimeString();
-      const lastSavedBadge = $('#lastSavedBadge');
-      if(lastSavedBadge){
-        lastSavedBadge.innerHTML = `<span class="pill-icon" aria-hidden="true">💾</span> Saved: ${lastSaved}`;
-      }
     }catch(e){
       console.warn('Failed to save state to localStorage', e);
-      const lastSavedBadge = $('#lastSavedBadge');
-      if(lastSavedBadge){ lastSavedBadge.textContent = 'Save failed'; }
     }
   }
 

--- a/index.html
+++ b/index.html
@@ -15,23 +15,6 @@
 
 </head>
 <body>
-<!--
-  ID INVENTORY:
-  stripes, critStripes, btnNew, btnLoad, btnSave, btnExportJSON, btnExportCSV, btnUndo, btnRedo,
-  btnPrint, btnGuide, btnToggleTheme, selBadge, scenarioBadge, lastSavedBadge,
-  boot, fatal, appRoot, startDate, startDateHelp, calendarMode, calendarModeHelp, holidayInput,
-  holidayInputHelp, slackThreshold, slackThresholdHelp, filterText, groupBy, groupByHelp,
-  btnFilterClear, btnSelectFiltered, btnClearSel, btnSubAll, btnSubNone, subsysFilters,
-  inlineCount, inlineEdit, bulkCount, bulkPhase, bulkSub, bulkActive, bulkDur, bulkDurMode,
-  bulkPrefix, bulkPct, bulkAddDep, bulkClearDeps, bulkShift, btnApplyBulk, btnBulkReset,
-  tplSelect, btnInsertTpl, btnAutoFix, severityFilter, issues, zoomOutGR, zoomInGR, zoomResetGR,
-  timeline, zoomOutTL, zoomInTL, zoomResetTL, gantt, gantt-accessible-summary, graph, graphSvg,
-  focus, finishMetric, critMetric, countMetric, impactMetric, nearList, focusWarnings, compare,
-  baselineSelect, btnUseBaseline, btnAddBaseline, cmpFinishA, cmpFinishB, cmpFinishDelta, cmpCritDelta, cmpList,
-  hint, toast, ctxMenu, help-modal, helpModalTitle, guided-workflow, guideModalTitle,
-  guideModalDescription, wz1, wz1Title, wz2, wz2Title, wz3, wz3Title, wz4, wz4Title, wz5,
-  wz5Title, wzPrev, wzNext, arrow
--->
   <svg style="position:absolute;width:0;height:0;overflow:hidden" aria-hidden="true">
     <defs>
       <pattern id="stripes" patternUnits="userSpaceOnUse" width="6" height="6" patternTransform="rotate(45)">
@@ -46,89 +29,6 @@
     </defs>
   </svg>
   <a href="#main-content" class="skip-link">Skip to main content</a>
-  <header class="legacy-header">
-    <div class="header-left">
-      <h1>
-        <span class="title-icon" aria-hidden="true">📊</span>
-        HPC/AI Project Planner
-        <small class="subtitle">— offline • single file</small>
-      </h1>
-    </div>
-    
-    <div class="header-center">
-      <div class="toolbar-group">
-        <h2 class="toolbar-heading">File</h2>
-        <div class="button-group">
-          <button class="btn" id="btnNew" aria-label="Create new project" title="Create new project">
-            <span class="btn-icon" aria-hidden="true">✨</span>
-            <span class="sr-only">New</span>
-          </button>
-          <button class="btn" id="btnLoad" aria-label="Open existing project file" title="Open existing project file">
-            <span class="btn-icon" aria-hidden="true">📁</span>
-            <span class="sr-only">Open…</span>
-          </button>
-          <button class="btn" id="btnSave" aria-label="Save current project" title="Save current project">
-            <span class="btn-icon" aria-hidden="true">💾</span>
-            <span class="sr-only">Save</span>
-          </button>
-          <button class="btn" id="btnExportJSON" aria-label="Export project data as JSON" title="Export project data as JSON">
-            <span class="btn-icon" aria-hidden="true">📤</span>
-            <span class="sr-only">Export JSON</span>
-          </button>
-          <button class="btn" id="btnExportCSV" aria-label="Export project data as CSV" title="Export project data as CSV">
-            <span class="btn-icon" aria-hidden="true">📊</span>
-            <span class="sr-only">Export CSV</span>
-          </button>
-          <button class="btn" id="btnImportCSV" aria-label="Import project data from CSV" title="Import project data from CSV">
-            <span class="btn-icon" aria-hidden="true">📥</span>
-            <span class="sr-only">Import CSV</span>
-          </button>
-          <input type="file" id="csvImportInput" accept=".csv" style="display:none" />
-        </div>
-      </div>
-      <div class="toolbar-group">
-        <h2 class="toolbar-heading">Tools</h2>
-        <div class="button-group">
-        <button class="btn" id="btnUndo" title="Undo (Ctrl+Z)" aria-label="Undo last action">
-            <span class="btn-icon" aria-hidden="true">↶</span>
-            <span class="sr-only">Undo</span>
-          </button>
-        <button class="btn" id="btnRedo" title="Redo (Ctrl+Y)" aria-label="Redo last undone action">
-            <span class="btn-icon" aria-hidden="true">↷</span>
-            <span class="sr-only">Redo</span>
-          </button>
-          <button class="btn accent" id="btnPrint" title="Print project or export as PDF" aria-label="Print project or export as PDF">
-            <span class="btn-icon" aria-hidden="true">🖨️</span>
-            <span class="sr-only">Print / PDF</span>
-          </button>
-          <button class="btn" id="btnGuide" aria-label="Show user guide and help" title="Show user guide and help">
-            <span class="btn-icon" aria-hidden="true">❓</span>
-            <span class="sr-only">Guide</span>
-          </button>
-          <button class="btn" id="btnToggleTheme" aria-label="Toggle dark mode" title="Toggle dark mode">
-            <span class="btn-icon" aria-hidden="true">🌙</span>
-            <span class="sr-only">Theme</span>
-          </button>
-        </div>
-      </div>
-    </div>
-    
-    <div class="right">
-      <div class="status-indicators">
-        <span class="pill status-pill" id="cpmStatusBadge" style="display:none; background-color: var(--warn); color: white;"><span class="pill-icon" aria-hidden="true">⏳</span>Calculating…</span>
-        <span class="pill status-pill" id="selBadge" role="status" aria-live="polite">
-          <span class="pill-icon" aria-hidden="true">🎯</span>
-          0 selected
-        </span>
-        <span class="pill status-pill" id="scenarioBadge" role="status" aria-live="polite">
-          <span class="pill-icon" aria-hidden="true">⚙️</span>
-          Scenario: Working
-        </span>
-        <span class="pill status-pill" id="lastSavedBadge" role="status" aria-live="polite"></span>
-      </div>
-      
-    </div>
-  </header>
 
   <header id="new-header" class="app-header">
     <div class="header-left">


### PR DESCRIPTION
## Summary
- strip legacy sidebar and header code
- drop obsolete styles and dead DOM references
- clean docs to reflect single toolbar layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8735b066883248558e511cab2b1dd